### PR TITLE
super wip mypy plugin implementation

### DIFF
--- a/hiku/mypy/plugin.py
+++ b/hiku/mypy/plugin.py
@@ -1,0 +1,58 @@
+from typing import Type as TypingType
+
+from mypy.errorcodes import ErrorCode
+from mypy.nodes import (
+    IndexExpr,
+    Context,
+    StrExpr,
+)
+from mypy.plugin import (
+    FunctionContext,
+    Plugin,
+    CheckerPluginInterface,
+)
+from mypy.types import Type
+
+
+ERROR_GRAPH_LINK_INVALID_OPTIONAL_TYPE = ErrorCode('hiku-graph-link', 'Invalid Link Optional type', 'Hiku')
+ERROR_GRAPH_LINK_INVALID_TYPE_REF_REF = ErrorCode('hiku-graph-link', 'Invalid Link TypeRef ref', 'Hiku')
+
+
+def error_invalid_optional_link_type(api: CheckerPluginInterface, context: Context) -> None:
+    api.fail('Link second argument Optional accepts only TypeRef in this context. Hint: Optional[TypeRef])', context, code=ERROR_GRAPH_LINK_INVALID_OPTIONAL_TYPE)
+
+
+def error_invalid_optional_link_type_ref_ref(api: CheckerPluginInterface, context: Context) -> None:
+    api.fail('Link second argument Optional[TypeRef[<>]] must reference existing Node in graph. Hint: Optional[TypeRef["node_name"]])', context, code=ERROR_GRAPH_LINK_INVALID_TYPE_REF_REF)
+
+
+def _hiku_graph_link_hook(ctx: FunctionContext) -> Type:
+    if ctx.api.path != 'examples/graphql_federation.py':
+        return ctx.default_return_type
+
+    assert ctx.callee_arg_names[1] == 'type_'
+    type_arg = ctx.args[1]
+    if isinstance(type_arg[0], IndexExpr):
+        index_expr = type_arg[0]
+        if index_expr.base.fullname == 'hiku.types.Optional':
+            # base is NameExpr
+            if index_expr.index.base.fullname != 'hiku.types.TypeRef':
+                error_invalid_optional_link_type(ctx.api, ctx.context)
+                return ctx.default_return_type
+
+            if not isinstance(index_expr.index.index, StrExpr):
+                error_invalid_optional_link_type_ref_ref(ctx.api, ctx.context)
+                return ctx.default_return_type
+
+    return ctx.default_return_type
+
+
+class HikuPlugin(Plugin):
+    def get_function_hook(self, fullname: str):
+        if fullname == 'hiku.graph.Link':
+            return _hiku_graph_link_hook
+
+
+def plugin(version: str) -> TypingType[Plugin]:
+    """Plugin entrypoint"""
+    return HikuPlugin

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,8 @@ exclude =
     tests
     tests_pg
 
+plugins = ./hiku/mypy/plugin.py
+
 [mypy-hiku.telemetry.*]
 disallow_untyped_defs = False
 check_untyped_defs = False
@@ -58,4 +60,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-prometheus_client.*]
+ignore_missing_imports = True
+
+# Ignore 3d-party from examples
+[mypy-flask.*]
 ignore_missing_imports = True


### PR DESCRIPTION
**Problem:**

Standard mypy capabilities is not sufficient to cover specific hiku's typing requirements.
 
For example, consider `Optional[TypeRef["User"]]` declaration.

Because of the way `hiku.types` implemented, mypy thinks that `Optional` is generic as well as `TypeRef`.

And even if we can declare `class Optional[Generic[T], OptionalMeta]): ...`,  making `TypeRef` gereric is still complicated.

Mypy think that in `TypeRef['User']`  TypeRef is generic over `User` type, but can not find it declared (because `User` is a ref for hiku node).

**Solution:**

We can create a mypy plugin for hiku in which we can implement any typechecking logic.

For example. here is a dummy implementation, that checks that `TypeRef` ref is a string (even better will be to check that there is Node for that ref)

![image](https://user-images.githubusercontent.com/10552804/184162280-240b0dc5-687a-4382-8a93-865ab99063ff.png)

