### PR TITLE
Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env
 .benchmarks
 todo
 TODO
+TODO.md
 .pdm-python
 __pypackages__
 examples/federation-compatibility/products.graphql

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Optional dependencies
 * `aiopg` - for async PostgreSQL support with `aiopg`
 * `asyncpg` - for async PostgreSQL support with `asyncpg`
 * `prometheus-client` - for Prometheus metrics support
+* `sentry-sdk` - for Sentry tracing support
 
 
 Highlights

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Query:
 
   engine = Engine(SyncExecutor())
 
-  result = engine.execute(GRAPH, build([
+  result = engine.execute_query(GRAPH, build([
       Q.characters[
           Q.name,
           Q.species,

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -30,26 +30,26 @@ This is the simplest :py:class:`~hiku.graph.Graph` with one
 
 Then this field could be queried using this query:
 
-.. code-block:: clojure
+.. code-block::
 
-    [:now]
+    { now }
 
 To perform this query let's define a helper function ``execute``:
 
 .. literalinclude:: basics/test_stage1.py
-    :lines: 15-25
+    :lines: 15-26
 
 Then we will be ready to execute our query:
 
 .. literalinclude:: basics/test_stage1.py
-    :lines: 34-35
+    :lines: 38-39
     :dedent: 4
 
 You can also test this graph using special web console application, this is how
 to setup and run it:
 
 .. literalinclude:: basics/test_stage1.py
-    :lines: 39-46
+    :lines: 43-50
 
 Then just open http://localhost:5000/ url in your browser and perform query from
 the console.
@@ -98,14 +98,14 @@ node. This function should return character ids.
 
 So now you are able to try this query in the console:
 
-.. code-block:: clojure
+.. code-block::
 
-  [{:characters [:name :species]}]
+  { characters { name species } }
 
 Or in the program:
 
 .. literalinclude:: basics/test_stage2.py
-    :lines: 51-67
+    :lines: 53-69
     :dedent: 4
 
 Linking node to node

--- a/docs/basics/test_stage1.py
+++ b/docs/basics/test_stage1.py
@@ -22,7 +22,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(query, graph)
+    result = hiku_engine.execute(graph, query)
     return denormalize(graph, result)
 
 

--- a/docs/basics/test_stage1.py
+++ b/docs/basics/test_stage1.py
@@ -21,7 +21,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(graph, query)
+    result = hiku_engine.execute_query(graph, query)
     return denormalize(graph, result)
 
 from tests.base import patch, Mock

--- a/docs/basics/test_stage1.py
+++ b/docs/basics/test_stage1.py
@@ -15,7 +15,7 @@ GRAPH = Graph([
 from hiku.engine import Engine
 from hiku.result import denormalize
 from hiku.executors.sync import SyncExecutor
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 
 hiku_engine = Engine(SyncExecutor())
 

--- a/docs/basics/test_stage1.py
+++ b/docs/basics/test_stage1.py
@@ -19,14 +19,18 @@ from hiku.readers.simple import read
 
 hiku_engine = Engine(SyncExecutor())
 
+
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute_query(graph, query)
+    result = hiku_engine.execute(query, graph)
     return denormalize(graph, result)
+
 
 from tests.base import patch, Mock
 
+
 _NOW = datetime(2015, 10, 21, 7, 28)
+
 
 @patch('{}.datetime'.format(__name__))
 def test(dt):

--- a/docs/basics/test_stage2.py
+++ b/docs/basics/test_stage2.py
@@ -14,7 +14,7 @@ from hiku.graph import Graph, Root, Field, Node, Link
 from hiku.types import TypeRef, Sequence
 from hiku.engine import Engine
 from hiku.result import denormalize
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.sync import SyncExecutor
 
 def character_data(fields, ids):
@@ -50,7 +50,7 @@ def execute(graph, query_string):
 
 
 def test():
-    result = execute(GRAPH, '[{:characters [:name :species]}]')
+    result = execute(GRAPH, "{ characters { name species } }")
     assert result == {
         "characters": [
             {

--- a/docs/basics/test_stage2.py
+++ b/docs/basics/test_stage2.py
@@ -45,7 +45,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(query, graph)
+    result = hiku_engine.execute(graph, query)
     return denormalize(graph, result)
 
 

--- a/docs/basics/test_stage2.py
+++ b/docs/basics/test_stage2.py
@@ -44,7 +44,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(graph, query)
+    result = hiku_engine.execute_query(graph, query)
     return denormalize(graph, result)
 
 def test():

--- a/docs/basics/test_stage2.py
+++ b/docs/basics/test_stage2.py
@@ -42,10 +42,12 @@ GRAPH = Graph([
 
 hiku_engine = Engine(SyncExecutor())
 
+
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute_query(graph, query)
+    result = hiku_engine.execute(query, graph)
     return denormalize(graph, result)
+
 
 def test():
     result = execute(GRAPH, '[{:characters [:name :species]}]')

--- a/docs/basics/test_stage3.py
+++ b/docs/basics/test_stage3.py
@@ -76,7 +76,7 @@ GRAPH = Graph([
 
 from hiku.engine import Engine
 from hiku.result import denormalize
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.sync import SyncExecutor
 
 hiku_engine = Engine(SyncExecutor())
@@ -87,7 +87,7 @@ def execute(graph, query_string):
     return denormalize(graph, result)
 
 def test_link():
-    result = execute(GRAPH, '[{:characters [:name {:actors [:name]}]}]')
+    result = execute(GRAPH, "{ characters { name actors { name } } }")
     assert result == {
         'characters': [
             {'name': 'James T. Kirk',
@@ -103,9 +103,7 @@ def test_link():
     }
 
 def test_link_cycle():
-    result = execute(GRAPH, '[{:characters'
-                            '  [:name {:actors'
-                            '          [:name {:character [:name]}]}]}]')
+    result = execute(GRAPH, "{ characters { name actors { name character { name } } } }")
     assert result == {
         'characters': [
             {'name': 'James T. Kirk',

--- a/docs/basics/test_stage3.py
+++ b/docs/basics/test_stage3.py
@@ -83,7 +83,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(graph, query)
+    result = hiku_engine.execute_query(graph, query)
     return denormalize(graph, result)
 
 def test_link():

--- a/docs/basics/test_stage3.py
+++ b/docs/basics/test_stage3.py
@@ -83,7 +83,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(query, graph)
+    result = hiku_engine.execute(graph, query)
     return denormalize(graph, result)
 
 def test_link():

--- a/docs/basics/test_stage3.py
+++ b/docs/basics/test_stage3.py
@@ -83,7 +83,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute_query(graph, query)
+    result = hiku_engine.execute(query, graph)
     return denormalize(graph, result)
 
 def test_link():

--- a/docs/changelog/changes_07.rst
+++ b/docs/changelog/changes_07.rst
@@ -6,7 +6,9 @@ Changes in 0.7
 
   - Dropped support for Python 3.6, which ended support on 2021-12-23
   - Added support for Python 3.10
+  - Added support for Python 3.11
   - Added support for `Apollo Federation (v1) <https://www.apollographql.com/docs/federation/v1/>`_
+  - Added support for `Apollo Federation v2 (v2 is default now)`
   - [internal] Refactored introspection directives
   - Added graph schema directives support
 
@@ -43,20 +45,25 @@ Changes in 0.7
 
   - Added mypy and typings to codebase
   - Added checks for link results that can not be hashed and extend errors. This must improve developer experience.
-  - Added caching for parsing graphql query. It is optional and can be enabled by calling :py:func:`hiku.readers.graphql.setup_query_cache`.
   - Added result cache - it is possible now to specify ``@cached`` directive to cache parts of the query. :ref:`Check cache documentation <caching-doc>`
   - ``Link(requires=['a', 'b'])`` can be specified as a list of strings. It is useful when you want to require multiple fields at once. It will pass a list of dicts to the resolver.
-  - Added support for Python 3.11
   - Added hints when failing on return values that are not hashable
   - Migrated to ``pdm`` package manager
   - Reformat code with ``black``
-  - Added support for Apollo Federation v2 (v2 is default now)
   - Added support for custom schema directives :ref:`Check directives documentation <directives-doc>`
   - Added `ID` type.
   - Added support for unions :ref:`Check unions documentation <unions-doc>`
   - Added support for interfaces :ref:`Check interfaces documentation <interfaces-doc>`
   - Added support for enums :ref:`Check enums documentation <enums-doc>`
   - Added support for custom scalars :ref:`Check custom scalars documentation <scalars-doc>`
+  - Added support for extensions :ref:`Check extensions documentation <extensions-doc>`
+    - Added ``QueryParseCache`` extension - cache parsed graphql queries ast.
+    - Added ``QueryTransformCache`` extension - cache transformed graphql ast into query Node.
+    - Added ``QueryValidationCache`` extension - cache query validation.
+    - Added ``QueryDepthValidator`` extension - validate query depth
+    - Added ``PrometheusMetrics`` extension - wrapper around ``GraphMetrics`` visitor
+    - Added ``PrometheusMetricsAsync`` extension - wrapper around ``AsyncGraphMetrics`` visitor
+
 
 Backward-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog/changes_07.rst
+++ b/docs/changelog/changes_07.rst
@@ -63,6 +63,7 @@ Changes in 0.7
     - Added ``QueryDepthValidator`` extension - validate query depth
     - Added ``PrometheusMetrics`` extension - wrapper around ``GraphMetrics`` visitor
     - Added ``PrometheusMetricsAsync`` extension - wrapper around ``AsyncGraphMetrics`` visitor
+  - Add new method ``Engine.execute_context``, which accepts ``ExecutionContext``. ``Engine.execute`` changed its signature and not dispatches to ``Engine.execute_context``.
 
 
 Backward-incompatible changes
@@ -70,3 +71,5 @@ Backward-incompatible changes
 
   - Dropped Python 3.6 support, minimum supported version now is Python 3.7
   - Validate Option's default value. Now if `type` is not marked as `Optiona[...]` and `default=None`, validation will fail.
+  - `Engine.execute` signature has changed. Now it accepts query as first argument, graph and mutation as second and third arguments.
+    Both graph and mutation are optional but at least one of them must be specified. Fourth argument is `ctx` dict which is optional.

--- a/docs/changelog/changes_07.rst
+++ b/docs/changelog/changes_07.rst
@@ -63,7 +63,9 @@ Changes in 0.7
     - Added ``QueryDepthValidator`` extension - validate query depth
     - Added ``PrometheusMetrics`` extension - wrapper around ``GraphMetrics`` visitor
     - Added ``PrometheusMetricsAsync`` extension - wrapper around ``AsyncGraphMetrics`` visitor
-  - Add new method ``Engine.execute_context``, which accepts ``ExecutionContext``. ``Engine.execute`` changed its signature and not dispatches to ``Engine.execute_context``.
+  - Add new method ``Engine.execute_context``, which accepts ``ExecutionContext``. ``Engine.execute`` now dispatches to ``Engine.execute_context``.
+  - Add new method ``Engine.execute_mutation``, which allows to execute query against mutation graph
+  - Add optional ``context`` argument to ``GraphqlEndpoint.dispatch`` method
 
 
 Backward-incompatible changes
@@ -71,5 +73,3 @@ Backward-incompatible changes
 
   - Dropped Python 3.6 support, minimum supported version now is Python 3.7
   - Validate Option's default value. Now if `type` is not marked as `Optiona[...]` and `default=None`, validation will fail.
-  - `Engine.execute` signature has changed. Now it accepts query as first argument, graph and mutation as second and third arguments.
-    Both graph and mutation are optional but at least one of them must be specified. Fourth argument is `ctx` dict which is optional.

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -81,18 +81,18 @@ Querying graph
 For testing purposes let's define helper function ``execute``:
 
 .. literalinclude:: test_database.py
-    :lines: 98-108
+    :lines: 98-109
 
 Testing one to many link:
 
 .. literalinclude:: test_database.py
-    :lines: 111-136
+    :lines: 111-138
     :dedent: 4
 
 Testing many to one link:
 
 .. literalinclude:: test_database.py
-    :lines: 139-167
+    :lines: 139-169
     :dedent: 4
 
 .. _SQLAlchemy: http://www.sqlalchemy.org

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -1,0 +1,46 @@
+Extensions
+==========
+
+.. _extensions-doc:
+
+Extensions allow you to add custom functionality to your graph.
+
+Extensions are classes that inherit from :class:`hiku.extensions.Extension`.
+
+Each extension has a set of methods that are called at different stages of
+graph processing.
+
+Here are all the methods that can be implemented:
+
+- :meth:`~hiku.extensions.Extension.on_graph` - when endpoint is created and transformations applied to graph
+- :meth:`~hiku.extensions.Extension.on_dispatch` - when query is dispatched to the endpoint
+- :meth:`~hiku.extensions.Extension.on_parse` - when query string is parsed into ast
+- :meth:`~hiku.extensions.Extension.on_operation` - when query ast parsed into query Node
+- :meth:`~hiku.extensions.Extension.on_validate` - when query is validated
+- :meth:`~hiku.extensions.Extension.on_execute` - when query is executed by engine
+
+Built-in extensions
+~~~~~~~~~~~~~~~~~~~
+
+- ``QueryParseCache`` - cache parsed graphql queries ast.
+- ``QueryTransformCache`` - cache transformed graphql ast into query Node.
+- ``QueryValidationCache`` - cache query validation.
+- ``QueryDepthValidator`` - validate query depth
+- ``PrometheusMetrics`` - wrapper around ``GraphMetrics`` visitor
+- ``PrometheusMetricsAsync`` - wrapper around ``AsyncGraphMetrics`` visitor
+
+
+Writing extension
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from hiku.extensions import Extension
+
+    class TimeItExtension(Extension):
+        def on_execute(self):
+            start = time.perf_counter()
+            yield
+            print('Query execution took {:.3f} seconds'.format(time.perf_counter() - start))
+
+    endpoint = GraphqlEndpoint(engine, graph, extensions=[TimeItExtension()])

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -14,6 +14,7 @@ Here are all the methods that can be implemented:
 
 - :meth:`~hiku.extensions.Extension.on_graph` - when endpoint is created and transformations applied to graph
 - :meth:`~hiku.extensions.Extension.on_dispatch` - when query is dispatched to the endpoint
+- :meth:`~hiku.extensions.Extension.on_context` - after query is dispatched to the endpoint but before query is executed
 - :meth:`~hiku.extensions.Extension.on_parse` - when query string is parsed into ast
 - :meth:`~hiku.extensions.Extension.on_operation` - when query ast parsed into query Node
 - :meth:`~hiku.extensions.Extension.on_validate` - when query is validated
@@ -28,6 +29,7 @@ Built-in extensions
 - ``QueryDepthValidator`` - validate query depth
 - ``PrometheusMetrics`` - wrapper around ``GraphMetrics`` visitor
 - ``PrometheusMetricsAsync`` - wrapper around ``AsyncGraphMetrics`` visitor
+- ``CustomContext`` - allows to pass custom context to the query execution
 
 
 Writing extension

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -14,7 +14,6 @@ Here are all the methods that can be implemented:
 
 - :meth:`~hiku.extensions.Extension.on_graph` - when endpoint is created and transformations applied to graph
 - :meth:`~hiku.extensions.Extension.on_dispatch` - when query is dispatched to the endpoint
-- :meth:`~hiku.extensions.Extension.on_context` - after query is dispatched to the endpoint but before query is executed
 - :meth:`~hiku.extensions.Extension.on_parse` - when query string is parsed into ast
 - :meth:`~hiku.extensions.Extension.on_operation` - when query ast parsed into query Node
 - :meth:`~hiku.extensions.Extension.on_validate` - when query is validated

--- a/docs/federation.rst
+++ b/docs/federation.rst
@@ -39,7 +39,7 @@ Let's start with a simple example of a federated subgraph using the following Gr
 
 Order Service
 
-.. code-block:: graphql
+.. code-block::
 
    type Order @key(fields: "id") {
        id: ID!
@@ -53,7 +53,7 @@ Order Service
 
 Shopping Cart Service
 
-.. code-block:: graphql
+.. code-block::
 
    type ShoppingCart @key(fields: "id") {
        id: ID!
@@ -224,7 +224,7 @@ With the composed schema, we can now start the router:
 
 With the router running, visit http://localhost:4000 and try running the following query:
 
-.. code-block:: graphql
+.. code-block::
 
     {
         order(id: 1) {

--- a/docs/graphql.rst
+++ b/docs/graphql.rst
@@ -146,11 +146,16 @@ execution result into JSON, it should be denormalized, to replace references
 Query parsing cache
 ~~~~~~~~~~~~~~~~~~~
 
-Hiku uses ``graphql-core`` library to parse queries. It is possible to enable
-cache for parsed queries. This is useful when you have a lot of queries, and you
-want to parse them only once.
+Hiku uses ``graphql-core`` library to parse queries. But parsing same query again and again is a waste of resources and time.
 
-Current implementation uses ``functools.lru_cache``.
+Hiku provides a way to cache parsed queries. To enable it, you need to use ``QueryParseCache`` extensions.
+
+.. code-block:: python
+
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[QueryParserCache(maxsize=50)],
+    )
 
 Note than for cache to be effective, you need to separate query and variables, otherwise
 cache will be useless.

--- a/docs/graphql.rst
+++ b/docs/graphql.rst
@@ -117,9 +117,9 @@ another:
 .. code-block:: python
 
   if op.type is OperationType.QUERY:
-      result = engine.execute(query_graph, op.query)
+      result = engine.execute_query(query_graph, op.query)
   elif op.type is OperationType.MUTATION:
-      result = engine.execute(mutation_graph, op.query)
+      result = engine.execute_mutation(mutation_graph, op.query)
   else:
       return {'errors': [{'message': ('Unsupported operation type: {!r}'
                                       .format(op.type))}]}
@@ -168,7 +168,7 @@ Query with inlined variables is bad for caching.
 
 Query with separated variables is good for caching.
 
-.. code-block:: python
+.. code-block::
 
     query User($id: ID!, $photoSize: Int) {
         user(id: $id) {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ User's Guide
   telemetry
   caching
   extensions
+  integrations
   reference/index
   changelog/index
   development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ User's Guide
   federation
   telemetry
   caching
+  extensions
   reference/index
   changelog/index
   development

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,0 +1,22 @@
+Integrations
+============
+
+You can dive into full examples in the `examples` folder.
+
+Flask
+-----
+
+.. literalinclude:: integrations/flask_example.py
+    :lines: 1-32
+
+Aiohttp
+-------
+
+.. literalinclude:: integrations/aiohttp_example.py
+    :lines: 1-37
+
+FastAPI
+-------
+
+.. literalinclude:: integrations/fastapi_example.py
+    :lines: 1-34

--- a/docs/integrations/aiohttp_example.py
+++ b/docs/integrations/aiohttp_example.py
@@ -1,0 +1,37 @@
+from aiohttp import web
+
+from hiku.types import String
+from hiku.graph import Graph, Root, Field
+from hiku.engine import Engine
+from hiku.endpoint.graphql import AsyncGraphQLEndpoint
+from hiku.executors.asyncio import AsyncIOExecutor
+
+
+def say_hello(fields):
+    return ['Hello World!' for _ in fields]
+
+
+QUERY_GRAPH = Graph([
+    Root([Field('hello', String, say_hello)]),
+])
+
+
+async def handle_graphql(request):
+    data = await request.json()
+    context = {
+        'redis': request.app['redis'],
+    }
+    result = await request.app['graphql-endpoint'].dispatch(data, context)
+    return web.json_response(result)
+
+
+if __name__ == "__main__":
+    app = web.Application()
+    app.add_routes([
+        web.post('/graphql', handle_graphql),
+    ])
+    app['graphql-endpoint'] = AsyncGraphQLEndpoint(
+        Engine(AsyncIOExecutor()), QUERY_GRAPH
+    )
+    app['redis'] = Redis()
+    web.run_app(app, host='0.0.0.0', port=5000)

--- a/docs/integrations/fastapi_example.py
+++ b/docs/integrations/fastapi_example.py
@@ -1,0 +1,34 @@
+import uvicorn
+from fastapi import FastAPI, Request
+
+from hiku.types import  String
+from hiku.graph import Graph, Root, Field
+from hiku.engine import Engine
+from hiku.endpoint.graphql import AsyncGraphQLEndpoint
+from hiku.executors.asyncio import AsyncIOExecutor
+
+def say_hello(fields):
+    return ['Hello World!' for _ in fields]
+
+QUERY_GRAPH = Graph([
+    Root([Field('hello', String, say_hello)]),
+])
+
+app = FastAPI()
+
+graphql_endpoint = AsyncGraphQLEndpoint(
+    Engine(AsyncIOExecutor()), QUERY_GRAPH
+)
+redis = Redis()
+
+@app.post('/graphql')
+async def handle_graphql(request: Request):
+    data = await request.json()
+    context = {
+        'redis': redis,
+    }
+    return await graphql_endpoint.dispatch(data, context)
+
+
+if __name__ == "__main__":
+    uvicorn.run(__name__ + ":app", port=5000, host="0.0.0.0")

--- a/docs/integrations/flask_example.py
+++ b/docs/integrations/flask_example.py
@@ -1,0 +1,32 @@
+from flask import Flask, request, jsonify
+
+from hiku.graph import Graph, Root, Field
+from hiku.types import String
+from hiku.engine import Engine
+from hiku.executors.sync import SyncExecutor
+from hiku.endpoint.graphql import GraphQLEndpoint
+
+app = Flask(__name__)
+
+redis = Redis()
+
+def say_hello(fields):
+    return ['Hello World!' for _ in fields]
+
+QUERY_GRAPH = Graph([
+    Root([Field('hello', String, say_hello)]),
+])
+
+graphql_endpoint = GraphQLEndpoint(
+    Engine(SyncExecutor()), QUERY_GRAPH
+)
+
+@app.route('/graphql', methods={'POST'})
+def graphql():
+    data = request.get_json()
+    context = {'redis': redis}
+    result = graphql_endpoint.dispatch(data, context)
+    return jsonify(result)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/docs/test_asyncio.py
+++ b/docs/test_asyncio.py
@@ -148,7 +148,7 @@ from hiku.executors.asyncio import AsyncIOExecutor
 
 async def execute(hiku_engine, sa_engine, graph, query_string):
     query = read(query_string)
-    result = await hiku_engine.execute_query(graph, query, {SA_ENGINE_KEY: sa_engine})
+    result = await hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 @pytest.mark.asyncio(forbid_global_loop=True)

--- a/docs/test_asyncio.py
+++ b/docs/test_asyncio.py
@@ -148,7 +148,7 @@ from hiku.executors.asyncio import AsyncIOExecutor
 
 async def execute(hiku_engine, sa_engine, graph, query_string):
     query = read(query_string)
-    result = await hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
+    result = await hiku_engine.execute(graph, query, {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 @pytest.mark.asyncio(forbid_global_loop=True)

--- a/docs/test_asyncio.py
+++ b/docs/test_asyncio.py
@@ -148,7 +148,7 @@ from hiku.executors.asyncio import AsyncIOExecutor
 
 async def execute(hiku_engine, sa_engine, graph, query_string):
     query = read(query_string)
-    result = await hiku_engine.execute(graph, query, {SA_ENGINE_KEY: sa_engine})
+    result = await hiku_engine.execute_query(graph, query, {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 @pytest.mark.asyncio(forbid_global_loop=True)

--- a/docs/test_database.py
+++ b/docs/test_database.py
@@ -97,7 +97,7 @@ GRAPH = Graph([
 
 from hiku.engine import Engine
 from hiku.result import denormalize
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.sync import SyncExecutor
 
 hiku_engine = Engine(SyncExecutor())
@@ -110,7 +110,7 @@ def execute(graph, query_string):
 
 
 def test_character_to_actors():
-    result = execute(GRAPH, '[{:characters [:name {:actors [:name]}]}]')
+    result = execute(GRAPH, '{ characters { name actors { name } } }')
     assert result == {
         'characters': [
             {
@@ -138,7 +138,7 @@ def test_character_to_actors():
     }
 
 def test_actor_to_character():
-    result = execute(GRAPH, '[{:actors [:name {:character [:name]}]}]')
+    result = execute(GRAPH, '{ actors { name character { name } } }')
     assert result == {
         'actors': [
             {

--- a/docs/test_database.py
+++ b/docs/test_database.py
@@ -104,7 +104,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(graph, query, {SA_ENGINE_KEY: sa_engine})
+    result = hiku_engine.execute_query(graph, query, {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 def test_character_to_actors():

--- a/docs/test_database.py
+++ b/docs/test_database.py
@@ -102,10 +102,12 @@ from hiku.executors.sync import SyncExecutor
 
 hiku_engine = Engine(SyncExecutor())
 
+
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute_query(graph, query, {SA_ENGINE_KEY: sa_engine})
+    result = hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
+
 
 def test_character_to_actors():
     result = execute(GRAPH, '[{:characters [:name {:actors [:name]}]}]')

--- a/docs/test_database.py
+++ b/docs/test_database.py
@@ -105,7 +105,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
+    result = hiku_engine.execute(graph, query, {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 

--- a/docs/test_protobuf.py
+++ b/docs/test_protobuf.py
@@ -53,6 +53,6 @@ def test_query_reading():
 
     query = read(binary_message)
 
-    result = hiku_engine.execute_query(GRAPH, query)
+    result = hiku_engine.execute(query, GRAPH)
 
     assert all(c['name'] for c in result['characters'])

--- a/docs/test_protobuf.py
+++ b/docs/test_protobuf.py
@@ -53,6 +53,6 @@ def test_query_reading():
 
     query = read(binary_message)
 
-    result = hiku_engine.execute(GRAPH, query)
+    result = hiku_engine.execute_query(GRAPH, query)
 
     assert all(c['name'] for c in result['characters'])

--- a/docs/test_protobuf.py
+++ b/docs/test_protobuf.py
@@ -53,6 +53,6 @@ def test_query_reading():
 
     query = read(binary_message)
 
-    result = hiku_engine.execute(query, GRAPH)
+    result = hiku_engine.execute(graph, query)
 
     assert all(c['name'] for c in result['characters'])

--- a/docs/test_subgraph.py
+++ b/docs/test_subgraph.py
@@ -89,7 +89,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
+    result = hiku_engine.execute(graph, query, {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 
 

--- a/docs/test_subgraph.py
+++ b/docs/test_subgraph.py
@@ -81,7 +81,7 @@ _GRAPH = Graph([
 
 from hiku.engine import Engine
 from hiku.result import denormalize
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.sync import SyncExecutor
 
 hiku_engine = Engine(SyncExecutor())
@@ -94,7 +94,7 @@ def execute(graph, query_string):
 
 
 def test_low_level():
-    result = execute(_GRAPH, '[{:characters [:name {:image [:id :name]}]}]')
+    result = execute(_GRAPH, '{ characters { name image { id name } } }')
     assert result == {
         'characters': [
             {'name': 'James T. Kirk',
@@ -138,7 +138,7 @@ GRAPH = Graph([
 # test high-level graph
 
 def test_high_level():
-    result = execute(GRAPH, '[{:characters [:name :image-url]}]')
+    result = execute(GRAPH, '{ characters { name image-url } }')
     assert result == {
         'characters': [
             {'name': 'James T. Kirk',

--- a/docs/test_subgraph.py
+++ b/docs/test_subgraph.py
@@ -88,7 +88,7 @@ hiku_engine = Engine(SyncExecutor())
 
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute(graph, query,
+    result = hiku_engine.execute_query(graph, query,
                                  {SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
 

--- a/docs/test_subgraph.py
+++ b/docs/test_subgraph.py
@@ -86,11 +86,12 @@ from hiku.executors.sync import SyncExecutor
 
 hiku_engine = Engine(SyncExecutor())
 
+
 def execute(graph, query_string):
     query = read(query_string)
-    result = hiku_engine.execute_query(graph, query,
-                                 {SA_ENGINE_KEY: sa_engine})
+    result = hiku_engine.execute(query, graph, ctx={SA_ENGINE_KEY: sa_engine})
     return denormalize(graph, result)
+
 
 def test_low_level():
     result = execute(_GRAPH, '[{:characters [:name {:image [:id :name]}]}]')

--- a/examples/federation-compatibility/server.py
+++ b/examples/federation-compatibility/server.py
@@ -31,7 +31,6 @@ from hiku.graph import (
     Node,
     Link,
 )
-from hiku.readers.graphql import setup_query_cache
 from hiku.types import (
     Float,
     ID,
@@ -596,7 +595,6 @@ def graphiql():
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
-    setup_query_cache(size=128)
     app.run(host="0.0.0.0", port=4001, debug=True)
 
 

--- a/examples/graphql_federation.py
+++ b/examples/graphql_federation.py
@@ -17,7 +17,6 @@ from hiku.graph import (
     Link,
     Graph,
 )
-from hiku.readers.graphql import setup_query_cache
 from hiku.types import (
     Integer,
     TypeRef,
@@ -146,7 +145,6 @@ def handle_graphql():
 
 def main():
     logging.basicConfig(level=logging.DEBUG)
-    setup_query_cache(size=128)
     app.run(host='0.0.0.0', port=5000, debug=True)
 
 

--- a/examples/graphql_federation_v2.py
+++ b/examples/graphql_federation_v2.py
@@ -12,7 +12,6 @@ from hiku.graph import (
     Option,
     Link,
 )
-from hiku.readers.graphql import setup_query_cache
 from hiku.types import (
     Integer,
     TypeRef,
@@ -154,7 +153,6 @@ def handle_graphql():
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
-    setup_query_cache(size=128)
     app.run(host='0.0.0.0', port=4001, debug=True)
 
 

--- a/hiku/builder.py
+++ b/hiku/builder.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .query import Node, Field, Link
 
 
@@ -42,7 +44,7 @@ class Handle:
 Q = Handle()
 
 
-def build(items):
+def build(items: List[Handle]) -> Node:
     """Builds a query
 
     Example:
@@ -73,7 +75,7 @@ def build(items):
             )
         else:
             query_items.append(
-                Link(
+                Link(  # type: ignore
                     handle.__field_name__,
                     build(handle.__node_items__),
                     handle.__field_options__,

--- a/hiku/cache.py
+++ b/hiku/cache.py
@@ -168,6 +168,9 @@ class CacheVisitor(QueryVisitor):
         self._node_idx: Deque[Dict] = deque()
 
     def visit_field(self, field: QueryField) -> None:
+        if field.name == "__typename":
+            return
+
         self._data[-1][field.index_key] = self._node_idx[-1][field.index_key]
         super().visit_field(field)
 

--- a/hiku/context.py
+++ b/hiku/context.py
@@ -77,9 +77,8 @@ class ExecutionContext:
         ):
             return self.mutation_graph
 
-        raise ValueError(
-            "Unsupported operation type: {!r}".format(self.operation.type)
-        )
+        assert self.query_graph is not None
+        return self.query_graph
 
 
 @dataclass

--- a/hiku/context.py
+++ b/hiku/context.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from graphql.language import ast
+
+from hiku.introspection.graphql import MUTATION_ROOT_NAME, QUERY_ROOT_NAME
+from hiku.result import Proxy
+from hiku.operation import Operation, OperationType
+from hiku.extensions.base_validator import QueryValidator
+from hiku.query import Node
+from hiku.graph import Graph, GraphTransformer
+
+_type_names: Dict[OperationType, str] = {
+    OperationType.QUERY: QUERY_ROOT_NAME,
+    OperationType.MUTATION: MUTATION_ROOT_NAME,
+}
+
+
+@dataclass
+class ExecutionContext:
+    query_src: str
+    variables: Optional[Dict[str, Any]]
+    context: Dict
+    graphql_document: Optional[ast.DocumentNode] = None
+    query: Optional[Node] = None
+    query_graph: Optional[Graph] = None
+    mutation_graph: Optional[Graph] = None
+    operation: Optional["Operation"] = None
+    """Operation name from request's json operationName"""
+    request_operation_name: Optional[str] = None
+    result: Optional[Proxy] = None
+    """If errors is list, validation was performed"""
+    errors: Optional[List[str]] = None
+
+    validators: Tuple[QueryValidator, ...] = field(
+        default_factory=lambda: tuple()
+    )
+    transformers: Tuple["GraphTransformer", ...] = field(
+        default_factory=lambda: tuple()
+    )
+
+    @property
+    def operation_name(self) -> Optional[str]:
+        if self.request_operation_name is not None:
+            return self.request_operation_name
+
+        if self.operation is None:
+            return None
+
+        return self.operation.name
+
+    @property
+    def operation_type_name(self) -> str:
+        if self.operation is None:
+            type_ = OperationType.QUERY
+        else:
+            type_ = self.operation.type
+
+        return _type_names[type_]
+
+    @property
+    def graph(self) -> Graph:
+        """If operation type isn't specified, returns query graph."""
+        if self.operation is None:
+            assert self.query_graph is not None
+            return self.query_graph
+
+        if (
+            self.operation.type is OperationType.QUERY
+            or self.operation.type is None
+        ):
+            assert self.query_graph is not None
+            return self.query_graph
+        elif (
+            self.operation.type is OperationType.MUTATION
+            and self.mutation_graph is not None
+        ):
+            return self.mutation_graph
+
+        raise ValueError(
+            "Unsupported operation type: {!r}".format(self.operation.type)
+        )
+
+
+@dataclass
+class ExecutionContextFinal(ExecutionContext):
+    """Final execution context, after validation and query transformation."""
+
+    operation: "Operation"  # type: ignore[misc]
+    query: Node  # type: ignore[misc]
+    query_graph: Graph  # type: ignore[misc]
+    mutation_graph: Optional[Graph] = None
+
+
+def create_execution_context(
+    query: Union[str, Node, None] = None,
+    variables: Optional[Dict] = None,
+    operation_name: Optional[str] = None,
+    query_graph: Optional[Graph] = None,
+    mutation_graph: Optional[Graph] = None,
+    context: Optional[Dict] = None,
+    **kwargs: Any,
+) -> ExecutionContext:
+    query_src = None
+    query_node = None
+    if isinstance(query, str):
+        query_src = query
+    elif isinstance(query, Node):
+        query_node = query
+
+    return ExecutionContext(
+        query_src=query_src or "",
+        variables=variables,
+        request_operation_name=operation_name,
+        context=context or {},
+        query_graph=query_graph,
+        mutation_graph=mutation_graph,
+        query=query_node,
+        **kwargs,
+    )

--- a/hiku/endpoint/graphql.py
+++ b/hiku/endpoint/graphql.py
@@ -243,7 +243,7 @@ class GraphQLEndpoint(BaseSyncGraphQLEndpoint):
             raise GraphQLError(errors=execution_context.errors)
 
         with extensions_manager.execution():
-            result = self.engine.execute(execution_context)
+            result = self.engine.execute_context(execution_context)
             assert isinstance(result, Proxy)
             execution_context.result = result
 
@@ -305,7 +305,7 @@ class AsyncGraphQLEndpoint(BaseAsyncGraphQLEndpoint):
             raise GraphQLError(errors=execution_context.errors)
 
         with extensions_manager.execution():
-            result = await self.engine.execute(execution_context)  # type: ignore[union-attr]  # noqa: E501
+            result = await self.engine.execute_context(execution_context)  # type: ignore[union-attr]  # noqa: E501
             execution_context.result = result
 
         return DenormalizeGraphQL(

--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -32,6 +32,7 @@ from .cache import (
 from .compat import Concatenate, ParamSpec
 from .context import ExecutionContext, create_execution_context
 from .executors.base import SyncAsyncExecutor
+from .operation import Operation, OperationType
 from .query import (
     Node as QueryNode,
     Field as QueryField,
@@ -979,15 +980,29 @@ class BaseEngine(abc.ABC):
 
     def execute(
         self,
+        graph: Graph,
         query: QueryNode,
-        graph: Optional[Graph] = None,
-        mutation_graph: Optional[Graph] = None,
         ctx: Optional[Dict] = None,
     ) -> Union[Proxy, Awaitable[Proxy]]:
-        assert graph is not None or mutation_graph is not None
-
         execution_context = create_execution_context(
-            query, query_graph=graph, mutation_graph=mutation_graph, context=ctx
+            query,
+            query_graph=graph,
+            context=ctx,
+            operation=Operation(OperationType.QUERY, query, None),
+        )
+        return self.execute_context(execution_context)
+
+    def execute_mutation(
+        self,
+        graph: Graph,
+        query: QueryNode,
+        ctx: Optional[Dict] = None,
+    ) -> Union[Proxy, Awaitable[Proxy]]:
+        execution_context = create_execution_context(
+            query,
+            mutation_graph=graph,
+            context=ctx,
+            operation=Operation(OperationType.MUTATION, query, None),
         )
         return self.execute_context(execution_context)
 

--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -971,31 +971,29 @@ class BaseEngine(abc.ABC):
         self.cache_settings = cache
 
     @abc.abstractmethod
-    def execute(
+    def execute_context(
         self,
         execution_context: ExecutionContext,
     ) -> Union[Proxy, Awaitable[Proxy]]:
         ...
 
-    def execute_query(
-        self, graph: Graph, query: QueryNode, ctx: Optional[Dict] = None
+    def execute(
+        self,
+        query: QueryNode,
+        graph: Optional[Graph] = None,
+        mutation_graph: Optional[Graph] = None,
+        ctx: Optional[Dict] = None,
     ) -> Union[Proxy, Awaitable[Proxy]]:
-        execution_context = create_execution_context(
-            query, query_graph=graph, context=ctx
-        )
-        return self.execute(execution_context)
+        assert graph is not None or mutation_graph is not None
 
-    def execute_mutation(
-        self, graph: Graph, query: QueryNode, ctx: Optional[Dict] = None
-    ) -> Union[Proxy, Awaitable[Proxy]]:
         execution_context = create_execution_context(
-            query, mutation_graph=graph, context=ctx
+            query, query_graph=graph, mutation_graph=mutation_graph, context=ctx
         )
-        return self.execute(execution_context)
+        return self.execute_context(execution_context)
 
 
 class Engine(BaseEngine):
-    def execute(
+    def execute_context(
         self,
         execution_context: ExecutionContext,
     ) -> Union[Proxy, Awaitable[Proxy]]:

--- a/hiku/extensions/__init__.py
+++ b/hiku/extensions/__init__.py
@@ -1,7 +1,5 @@
 from .base_extension import Extension
-from .query_parse_cache import QueryParserCache
 
 __all__ = [
     "Extension",
-    "QueryParserCache",
 ]

--- a/hiku/extensions/__init__.py
+++ b/hiku/extensions/__init__.py
@@ -1,0 +1,7 @@
+from .base_extension import Extension
+from .query_parse_cache import QueryParserCache
+
+__all__ = [
+    "Extension",
+    "QueryParserCache",
+]

--- a/hiku/extensions/base_extension.py
+++ b/hiku/extensions/base_extension.py
@@ -41,11 +41,15 @@ class Extension:
         self.execution_context = execution_context  # type: ignore[assignment]
 
     def on_graph(self) -> AsyncIteratorOrIterator[None]:
-        """Called before the graph transformation step"""
+        """Called before and after the graph (transformation) step"""
         yield None
 
     def on_dispatch(self) -> AsyncIteratorOrIterator[None]:
         """Called before and after the dispatch step"""
+        yield None
+
+    def on_context(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the context step"""
         yield None
 
     def on_operation(self) -> AsyncIteratorOrIterator[None]:
@@ -98,6 +102,12 @@ class ExtensionsManager:
     def dispatch(self) -> "ExtensionContextManagerBase":
         return ExtensionContextManagerBase(
             Extension.on_dispatch.__name__,
+            self.extensions,
+        )
+
+    def context(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_context.__name__,
             self.extensions,
         )
 

--- a/hiku/extensions/base_extension.py
+++ b/hiku/extensions/base_extension.py
@@ -41,31 +41,68 @@ class Extension:
         self.execution_context = execution_context  # type: ignore[assignment]
 
     def on_graph(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the graph (transformation) step"""
+        """Called before and after the graph (transformation) step.
+
+        Graph transformation step is a step where we applying transformations
+        to the graph such as introspection, etc.
+
+        Note: unlike other hooks, this hook is called only once during endpoint
+        creation.
+        """
         yield None
 
     def on_dispatch(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the dispatch step"""
-        yield None
+        """Called before and after the dispatch step.
 
-    def on_context(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the context step"""
+        Dispatch step is a step where the query is dispatched by to the endpoint
+        to be parsed, validated and executed.
+
+        At this step the:
+        - execution_context.query_src is set to the query string
+            from request
+        - execution_context.variables is set to the query variables
+            from request
+        - execution_context.operation_name is set to the query operation name
+            from request
+        - execution_context.query_graph is set to the query graph
+        - execution_context.mutation_graph is set to the mutation graph
+        - execution_context.context is set to the context from dispatch argument
+        """
         yield None
 
     def on_operation(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the operation step"""
+        """Called before and after the operation step.
+
+        Operation step is a step where the graphql ast is transformed into
+        hiku's query ast and Operation type is created and assigned to the
+        execution_context.operation.
+        """
         yield None
 
     def on_parse(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the parsing step"""
+        """Called before and after the parsing step.
+
+        Parse step is when query string is parsed into graphql ast
+        and will be assigned to the execution_context.graphql_document.
+        """
         yield None
 
     def on_validate(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the validation step"""
+        """Called before and after the validation step.
+
+        Validation step is when hiku query is validated.
+        After validation is done, if there are errors, they will be assigned
+        to the execution_context.errors.
+        """
         yield None
 
     def on_execute(self) -> AsyncIteratorOrIterator[None]:
-        """Called before and after the execution step"""
+        """Called before and after the execution step.
+
+        Execution step is when hiku query is executed by hiku engine.
+
+        After execution, normalized result(Proxy) will be assigned
+        to execution_context.result."""
         yield None
 
 
@@ -102,12 +139,6 @@ class ExtensionsManager:
     def dispatch(self) -> "ExtensionContextManagerBase":
         return ExtensionContextManagerBase(
             Extension.on_dispatch.__name__,
-            self.extensions,
-        )
-
-    def context(self) -> "ExtensionContextManagerBase":
-        return ExtensionContextManagerBase(
-            Extension.on_context.__name__,
             self.extensions,
         )
 

--- a/hiku/extensions/base_extension.py
+++ b/hiku/extensions/base_extension.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import contextlib
+import inspect
+from asyncio import iscoroutinefunction
+
+from types import TracebackType
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+    Type,
+    TypeVar,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from hiku.context import ExecutionContext
+
+
+T = TypeVar("T")
+
+AwaitableOrValue = Union[Awaitable[T], T]
+AsyncIteratorOrIterator = Union[AsyncIterator[T], Iterator[T]]
+Hook = Callable[["Extension"], AsyncIteratorOrIterator[None]]
+
+
+class Extension:
+    execution_context: ExecutionContext
+
+    def __init__(self, *, execution_context: Optional[ExecutionContext] = None):
+        # execution_context will be set during ExtensionsManager initialization
+        # it is safe to assume that it will be not None
+        self.execution_context = execution_context  # type: ignore[assignment]
+
+    def on_graph(self) -> AsyncIteratorOrIterator[None]:
+        """Called before the graph transformation step"""
+        yield None
+
+    def on_dispatch(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the dispatch step"""
+        yield None
+
+    def on_operation(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the operation step"""
+        yield None
+
+    def on_parse(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the parsing step"""
+        yield None
+
+    def on_validate(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the validation step"""
+        yield None
+
+    def on_execute(self) -> AsyncIteratorOrIterator[None]:
+        """Called before and after the execution step"""
+        yield None
+
+
+class ExtensionsManager:
+    def __init__(
+        self,
+        execution_context: ExecutionContext,
+        extensions: Sequence[Union[Type[Extension], Extension]],
+    ):
+        self.execution_context = execution_context
+
+        if not extensions:
+            extensions = []
+
+        init_extensions: List[Extension] = []
+
+        for extension in extensions:
+            if isinstance(extension, Extension):
+                extension.execution_context = execution_context
+                init_extensions.append(extension)
+            else:
+                init_extensions.append(
+                    extension(execution_context=execution_context)
+                )
+
+        self.extensions = init_extensions
+
+    def graph(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_graph.__name__,
+            self.extensions,
+        )
+
+    def dispatch(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_dispatch.__name__,
+            self.extensions,
+        )
+
+    def parsing(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_parse.__name__,
+            self.extensions,
+        )
+
+    def operation(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_operation.__name__,
+            self.extensions,
+        )
+
+    def validation(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_validate.__name__,
+            self.extensions,
+        )
+
+    def execution(self) -> "ExtensionContextManagerBase":
+        return ExtensionContextManagerBase(
+            Extension.on_execute.__name__,
+            self.extensions,
+        )
+
+
+class WrappedHook(NamedTuple):
+    extension: Extension
+    initialized_hook: Union[AsyncIterator[None], Iterator[None]]
+    is_async: bool
+
+
+class ExtensionContextManagerBase:
+    __slots__ = ("hook_name", "hooks", "deprecation_message", "default_hook")
+
+    def __init__(self, hook_name: str, extensions: List[Extension]):
+        self.hook_name = hook_name
+        self.hooks: List[WrappedHook] = []
+        self.default_hook: Hook = getattr(Extension, self.hook_name)
+        for extension in extensions:
+            hook = self.get_hook(extension)
+            if hook:
+                self.hooks.append(hook)
+
+    def get_hook(self, extension: Extension) -> Optional[WrappedHook]:
+        hook_fn: Optional[Hook] = getattr(type(extension), self.hook_name)
+        hook_fn = hook_fn if hook_fn is not self.default_hook else None
+
+        if hook_fn:
+            if inspect.isgeneratorfunction(hook_fn):
+                return WrappedHook(extension, hook_fn(extension), False)
+
+            if inspect.isasyncgenfunction(hook_fn):
+                return WrappedHook(extension, hook_fn(extension), True)
+
+            if callable(hook_fn):
+                return self.from_callable(extension, hook_fn)
+
+            raise ValueError(
+                f"Hook {self.hook_name} on {extension} "
+                f"must be callable, received {hook_fn!r}"
+            )
+
+        return None
+
+    @staticmethod
+    def from_callable(
+        extension: Extension,
+        func: Callable[[Extension], AwaitableOrValue[Any]],
+    ) -> WrappedHook:
+        if iscoroutinefunction(func):
+
+            async def async_iterator():  # type: ignore[no-untyped-def]
+                await func(extension)
+                yield
+
+            hook = async_iterator()
+            return WrappedHook(extension, hook, True)
+        else:
+
+            def iterator():  # type: ignore[no-untyped-def]
+                func(extension)
+                yield
+
+            hook = iterator()
+            return WrappedHook(extension, hook, False)
+
+    def run_hooks_sync(self, is_exit: bool = False) -> None:
+        """Run extensions synchronously."""
+        ctx = (
+            contextlib.suppress(StopIteration, StopAsyncIteration)
+            if is_exit
+            else contextlib.nullcontext()
+        )
+        for hook in self.hooks:
+            with ctx:
+                if hook.is_async:
+                    raise RuntimeError(
+                        f"Extension hook {hook.extension}.{self.hook_name} "
+                        "is async."
+                    )
+                else:
+                    hook.initialized_hook.__next__()  # type: ignore[union-attr]
+
+    def __enter__(self):  # type: ignore[no-untyped-def]
+        self.run_hooks_sync()
+
+    def __exit__(  # type: ignore[no-untyped-def]
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
+        self.run_hooks_sync(is_exit=True)
+
+    # TODO: support async

--- a/hiku/extensions/base_validator.py
+++ b/hiku/extensions/base_validator.py
@@ -1,0 +1,12 @@
+from abc import abstractmethod
+from typing import List
+
+from hiku.graph import Graph
+from hiku.query import Node, QueryVisitor
+
+
+class QueryValidator(QueryVisitor):
+    @abstractmethod
+    def validate(self, query: Node, graph: Graph) -> List[str]:
+        """Returns list of errors"""
+        ...

--- a/hiku/extensions/context.py
+++ b/hiku/extensions/context.py
@@ -1,0 +1,18 @@
+from typing import Callable, Dict, Iterator
+
+from hiku.context import ExecutionContext
+from hiku.extensions.base_extension import Extension
+
+
+class CustomContext(Extension):
+    def __init__(
+        self,
+        get_context: Callable[[ExecutionContext], Dict],
+    ):
+        self.get_context = get_context
+
+    def on_context(self) -> Iterator[None]:
+        self.execution_context.context = self.get_context(
+            self.execution_context
+        )
+        yield

--- a/hiku/extensions/context.py
+++ b/hiku/extensions/context.py
@@ -11,7 +11,7 @@ class CustomContext(Extension):
     ):
         self.get_context = get_context
 
-    def on_context(self) -> Iterator[None]:
+    def on_execute(self) -> Iterator[None]:
         self.execution_context.context = self.get_context(
             self.execution_context
         )

--- a/hiku/extensions/prometheus.py
+++ b/hiku/extensions/prometheus.py
@@ -1,0 +1,43 @@
+from typing import Iterator, Optional, Type
+
+from prometheus_client.metrics import MetricWrapperBase
+
+from hiku.telemetry.prometheus import (
+    AsyncGraphMetrics,
+    GraphMetrics,
+    GraphMetricsBase,
+    metrics_ctx,
+)
+from hiku.extensions.base_extension import Extension
+
+
+class PrometheusMetrics(Extension):
+    def __init__(
+        self,
+        name: str,
+        metric: Optional[MetricWrapperBase] = None,
+        transformer_cls: Type[GraphMetricsBase] = GraphMetrics,
+    ):
+        self._name = name
+        self._metric = metric
+        self._transformer = transformer_cls(self._name, metric=self._metric)
+
+    def on_graph(self) -> Iterator[None]:
+        self.execution_context.transformers = (
+            self.execution_context.transformers + (self._transformer,)
+        )
+        yield
+
+    def on_execute(self) -> Iterator[None]:
+        token = metrics_ctx.set(self.execution_context.context)
+        yield
+        metrics_ctx.reset(token)
+
+
+class PrometheusMetricsAsync(PrometheusMetrics):
+    def __init__(
+        self,
+        name: str,
+        metric: Optional[MetricWrapperBase] = None,
+    ):
+        super().__init__(name, metric=metric, transformer_cls=AsyncGraphMetrics)

--- a/hiku/extensions/query_depth_validator.py
+++ b/hiku/extensions/query_depth_validator.py
@@ -2,7 +2,7 @@ from typing import Iterator, List
 
 from hiku.graph import Graph
 
-from hiku.extensions import Extension
+from hiku.extensions.base_extension import Extension
 from hiku.extensions.base_validator import QueryValidator
 from hiku.query import Field, Link, Node
 

--- a/hiku/extensions/query_depth_validator.py
+++ b/hiku/extensions/query_depth_validator.py
@@ -1,0 +1,73 @@
+from typing import Iterator, List
+
+from hiku.graph import Graph
+
+from hiku.extensions import Extension
+from hiku.extensions.base_validator import QueryValidator
+from hiku.query import Field, Link, Node
+
+
+def is_introspection_key(key: str) -> bool:
+    """See: https://spec.graphql.org/June2018/#sec-Schema"""
+    return key.startswith("__")
+
+
+class _QueryDepthValidator(QueryValidator):
+    max_depth: int
+
+    """
+    :param max_depth: maximum allowed query depth
+    """
+
+    def __init__(self, max_depth: int):
+        self.max_depth = max_depth
+        self._current_depth = 0
+        self._final_depth = 0
+
+    def validate(self, query: Node, graph: Graph) -> List[str]:
+        depth = self.calculate(query)
+        if depth > self.max_depth:
+            return [
+                f"Query depth {depth} exceeds maximum "
+                f"allowed depth {self.max_depth}"
+            ]
+
+        return []
+
+    def calculate(self, obj: Node) -> int:
+        self.visit(obj)
+        return self._final_depth
+
+    def visit_field(self, obj: Field) -> None:
+        pass  # Do nothing for individual fields.
+
+    def visit_link(self, obj: Link) -> None:
+        if not is_introspection_key(obj.name):
+            super().visit_link(obj)
+
+    def visit_node(self, obj: Node) -> None:
+        self._current_depth += 1
+        self._final_depth = max(self._final_depth, self._current_depth)
+        super().visit_node(obj)
+        self._current_depth -= 1
+
+
+class QueryDepthValidator(Extension):
+    """Use this extension to limit the maximum allowed query depth.
+
+    Example:
+        Endpoint(engine, graph, extensions=[
+            QueryDepthValidator(max_depth=10),
+        ])
+
+    """
+
+    def __init__(self, max_depth: int):
+        self._validator = _QueryDepthValidator(max_depth)
+
+    def on_dispatch(self) -> Iterator[None]:
+        self.execution_context.validators = (
+            self.execution_context.validators + tuple([self._validator])
+        )
+
+        yield

--- a/hiku/extensions/query_parse_cache.py
+++ b/hiku/extensions/query_parse_cache.py
@@ -1,0 +1,37 @@
+from functools import lru_cache
+from typing import Iterator, Optional
+
+from prometheus_client import Gauge
+
+from hiku.extensions.base_extension import Extension
+from hiku.readers.graphql import parse_query
+
+
+QUERY_CACHE_HITS = Gauge("hiku_query_cache_hits", "Query cache hits")
+QUERY_CACHE_MISSES = Gauge("hiku_query_cache_misses", "Query cache misses")
+
+
+class QueryParserCache(Extension):
+    """Sets up lru cache for the ast parsing.
+
+    Exposes two metrics:
+    - hiku_query_cache_hits
+    - hiku_query_cache_misses
+
+    :param int maxsize: Maximum size of the cache
+    """
+
+    def __init__(self, maxsize: Optional[int] = None):
+        self.cached_parser = lru_cache(maxsize=maxsize)(parse_query)
+
+    def on_parse(self) -> Iterator[None]:
+        execution_context = self.execution_context
+
+        execution_context.graphql_document = self.cached_parser(
+            execution_context.query_src,
+        )
+
+        info = self.cached_parser.cache_info()
+        QUERY_CACHE_HITS.set(info.hits)
+        QUERY_CACHE_MISSES.set(info.misses)
+        yield

--- a/hiku/extensions/query_transform_cache.py
+++ b/hiku/extensions/query_transform_cache.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+from typing import Iterator, Optional
+
+from hiku.utils import to_immutable_dict
+
+from hiku.extensions.base_extension import Extension
+from hiku.readers.graphql import read_operation
+
+
+class QueryTransformCache(Extension):
+    """Sets up lru cache for the ast to Node transformation.
+
+    :param int maxsize: Maximum size of the cache
+    """
+
+    def __init__(self, maxsize: Optional[int] = None):
+        self.cached_operation_reader = lru_cache(maxsize=maxsize)(
+            read_operation
+        )
+
+    def on_operation(self) -> Iterator[None]:
+        execution_context = self.execution_context
+
+        execution_context.operation = self.cached_operation_reader(
+            execution_context.graphql_document,
+            to_immutable_dict(execution_context.variables)
+            if execution_context.variables
+            else None,
+            execution_context.request_operation_name,
+        )
+
+        yield

--- a/hiku/extensions/query_validation_cache.py
+++ b/hiku/extensions/query_validation_cache.py
@@ -1,0 +1,26 @@
+from functools import lru_cache
+from typing import Iterator, Optional
+
+from hiku.endpoint.graphql import _run_validation
+from hiku.extensions.base_extension import Extension
+
+
+class QueryValidationCache(Extension):
+    """Sets up lru cache for the query Node validation.
+
+    :param int maxsize: Maximum size of the cache
+    """
+
+    def __init__(self, maxsize: Optional[int] = None):
+        self.cached_validator = lru_cache(maxsize=maxsize)(_run_validation)
+
+    def on_validate(self) -> Iterator[None]:
+        execution_context = self.execution_context
+
+        execution_context.errors = self.cached_validator(
+            execution_context.graph,
+            execution_context.query,
+            execution_context.validators,
+        )
+
+        yield

--- a/hiku/extensions/sentry.py
+++ b/hiku/extensions/sentry.py
@@ -1,0 +1,74 @@
+import hashlib
+
+from typing import Iterator, Optional
+
+from hiku.utils import cached_property
+from sentry_sdk import configure_scope, start_span
+
+from hiku.context import ExecutionContext
+from hiku.extensions.base_extension import Extension
+
+
+class SentryTracing(Extension):
+    def __init__(
+        self,
+        *,
+        execution_context: Optional[ExecutionContext] = None,
+    ):
+        super().__init__(execution_context=execution_context)
+
+    @cached_property
+    def _resource_name(self) -> str:
+        assert self.execution_context.query
+
+        query_hash = self._hash_query(self.execution_context.query_src)
+
+        if self.execution_context.operation_name:
+            return f"{self.execution_context.operation_name}:{query_hash}"
+
+        return query_hash
+
+    def _hash_query(self, query: str) -> str:
+        return hashlib.md5(query.encode("utf-8")).hexdigest()
+
+    def on_dispatch(self) -> Iterator[None]:
+        self._operation_name = self.execution_context.operation_name
+        name = self._operation_name or "Anonymous Query"
+
+        with configure_scope() as scope:
+            if scope.span:
+                self.gql_span = scope.span.start_child(
+                    op="gql", description=name
+                )
+            else:
+                self.gql_span = start_span(op="gql")
+
+        operation_type = self.execution_context.operation_type_name
+
+        self.gql_span.set_tag("graphql.operation_type", operation_type)
+        self.gql_span.set_tag("graphql.resource_name", self._resource_name)
+        self.gql_span.set_data(
+            "graphql.query", self.execution_context.query_src
+        )
+
+        yield
+
+        self.gql_span.finish()
+
+    def on_validate(self) -> Iterator[None]:
+        self.validation_span = self.gql_span.start_child(
+            op="validation", description="Validation"
+        )
+
+        yield
+
+        self.validation_span.finish()
+
+    def on_parse(self) -> Iterator[None]:
+        self.parsing_span = self.gql_span.start_child(
+            op="parsing", description="Parsing"
+        )
+
+        yield
+
+        self.parsing_span.finish()

--- a/hiku/federation/endpoint.py
+++ b/hiku/federation/endpoint.py
@@ -182,6 +182,8 @@ class BaseSyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
             context=context,
+            query_graph=self.query_graph,
+            mutation_graph=self.mutation_graph,
         )
 
         extensions_manager = ExtensionsManager(
@@ -194,8 +196,7 @@ class BaseSyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
                 self._init_execution_context(
                     execution_context, extensions_manager
                 )
-                with extensions_manager.context():
-                    result = self.execute(execution_context, extensions_manager)
+                result = self.execute(execution_context, extensions_manager)
                 return {"data": result}
         except GraphQLError as e:
             return {"errors": [{"message": e} for e in e.errors]}
@@ -218,6 +219,8 @@ class BaseAsyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
             context=context,
+            query_graph=self.query_graph,
+            mutation_graph=self.mutation_graph,
         )
 
         extensions_manager = ExtensionsManager(
@@ -230,10 +233,9 @@ class BaseAsyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
                 self._init_execution_context(
                     execution_context, extensions_manager
                 )
-                with extensions_manager.context():
-                    result = await self.execute(
-                        execution_context, extensions_manager
-                    )
+                result = await self.execute(
+                    execution_context, extensions_manager
+                )
                 return {"data": result}
         except GraphQLError as e:
             return {"errors": [{"message": e} for e in e.errors]}
@@ -292,6 +294,8 @@ class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
             context=context,
+            query_graph=self.query_graph,
+            mutation_graph=self.mutation_graph,
         )
 
         extensions_manager = ExtensionsManager(
@@ -304,8 +308,7 @@ class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
                 self._init_execution_context(
                     execution_context, extensions_manager
                 )
-                with extensions_manager.context():
-                    result = self.execute(execution_context, extensions_manager)
+                result = self.execute(execution_context, extensions_manager)
                 return {"data": result}
         except GraphQLError as e:
             return {"errors": [{"message": e} for e in e.errors]}

--- a/hiku/federation/endpoint.py
+++ b/hiku/federation/endpoint.py
@@ -274,7 +274,7 @@ class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
                     self.federation_version,
                 )
 
-            result = self.engine.execute(execution_context)
+            result = self.engine.execute_context(execution_context)
             assert isinstance(result, Proxy)
             execution_context.result = result
 
@@ -341,7 +341,7 @@ class AsyncFederatedGraphQLEndpoint(BaseAsyncFederatedGraphQLEndpoint):
                     self.federation_version,
                 )
 
-            coro = self.engine.execute(execution_context)
+            coro = self.engine.execute_context(execution_context)
             assert isawaitable(coro)
             result = await coro
             execution_context.result = result

--- a/hiku/federation/endpoint.py
+++ b/hiku/federation/endpoint.py
@@ -1,21 +1,27 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
+from abc import abstractmethod
 from asyncio import gather
-from contextlib import contextmanager
 from inspect import isawaitable
 from typing import (
+    Callable,
     List,
     Dict,
     Any,
     Optional,
+    Sequence,
+    Tuple,
+    cast,
     overload,
-    Iterator,
     Union,
     Type,
 )
 
+from hiku.context import (
+    ExecutionContext,
+    ExecutionContextFinal,
+    create_execution_context,
+)
+from hiku.extensions.base_extension import Extension, ExtensionsManager
+from hiku.extensions.base_validator import QueryValidator
 from hiku.federation.utils import get_entity_types
 from hiku.federation.version import DEFAULT_FEDERATION_VERSION
 
@@ -28,29 +34,36 @@ from hiku.federation.introspection import (
     FederatedGraphQLIntrospection,
     AsyncFederatedGraphQLIntrospection,
 )
-from hiku.federation.validate import validate
 
 from hiku.denormalize.graphql import DenormalizeGraphQL
 from hiku.federation.denormalize import DenormalizeEntityGraphQL
 from hiku.endpoint.graphql import (
-    _type_names,
-    _switch_graph,
+    BaseGraphQLEndpoint,
     GraphQLError,
-    _StripQuery,
+    _run_validation as _run_validation_base,
 )
-from hiku.graph import GraphTransformer, apply, Union as GraphUnion
+from hiku.graph import (
+    GraphTransformer,
+    apply,
+    Union as GraphUnion,
+    Graph as _Graph,
+)
 from hiku.query import Node
 from hiku.result import Proxy
-from hiku.readers.graphql import Operation
 
 
-def _process_query(graph: Graph, query: Node) -> Node:
-    stripped_query = _StripQuery().visit(query)
-    errors = validate(graph, stripped_query)
-    if errors:
-        raise GraphQLError(errors=errors)
-    else:
-        return stripped_query
+GraphT = Union[Graph, _Graph]
+
+
+def _run_validation(
+    graph: GraphT,
+    query: Node,
+    validators: Optional[Tuple[QueryValidator, ...]] = None,
+) -> List[str]:
+    if "_entities" in query.fields_map or "_service" in query.fields_map:
+        return []
+
+    return _run_validation_base(graph, query, validators)
 
 
 def denormalize_entities(
@@ -90,10 +103,15 @@ class FederationV1EntityTransformer(GraphTransformer):
         )
 
 
-class BaseFederatedGraphEndpoint(ABC):
+class BaseFederatedGraphEndpoint(BaseGraphQLEndpoint):
     query_graph: Graph
     mutation_graph: Optional[Graph]
+    engine: Engine
+    batching: bool
+    validation: bool
+    introspection: bool
     federation_version: int
+    get_context: Optional[Callable[[ExecutionContext], Any]]
 
     @property
     @abstractmethod
@@ -105,15 +123,40 @@ class BaseFederatedGraphEndpoint(ABC):
         engine: Engine,
         query_graph: Graph,
         mutation_graph: Optional[Graph] = None,
+        batching: bool = False,
+        validation: bool = True,
+        introspection: bool = True,
+        extensions: Optional[
+            Sequence[Union[Extension, Type[Extension]]]
+        ] = None,
+        get_context: Optional[Callable[[ExecutionContext], Any]] = None,
         federation_version: int = DEFAULT_FEDERATION_VERSION,
     ):
         self.engine = engine
         self.federation_version = federation_version
+        self.introspection = introspection
+        self.batching = batching
+        self.validation = validation
+        self.extensions = extensions or []
+        self.get_context = get_context
 
-        introspection = self.introspection_cls(query_graph, mutation_graph)
-        transformers: List[GraphTransformer] = [introspection]
+        execution_context = create_execution_context()
+        extensions_manager = ExtensionsManager(
+            execution_context=execution_context,
+            extensions=self.extensions,
+        )
+        with extensions_manager.graph():
+            transformers: List[GraphTransformer] = list(
+                execution_context.transformers
+            )
+
         if federation_version == 1:
-            transformers.insert(0, FederationV1EntityTransformer())
+            transformers.append(FederationV1EntityTransformer())
+
+        if self.introspection:
+            transformers.append(
+                self.introspection_cls(query_graph, mutation_graph)
+            )
 
         self.query_graph = apply(query_graph, transformers)
         if mutation_graph is not None:
@@ -121,29 +164,77 @@ class BaseFederatedGraphEndpoint(ABC):
         else:
             self.mutation_graph = None
 
-    @contextmanager
-    def context(self, op: Operation) -> Iterator[Dict]:
-        yield {}
-
 
 class BaseSyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
     @abstractmethod
-    def execute(self, graph: Graph, op: Operation, ctx: Dict) -> Dict:
+    def execute(
+        self,
+        execution_context: ExecutionContext,
+        extensions_manager: ExtensionsManager,
+    ) -> Dict:
         pass
 
-    @abstractmethod
     def dispatch(self, data: Dict) -> Dict:
-        pass
+        execution_context = create_execution_context(
+            query=data["query"],
+            variables=data.get("variables"),
+            operation_name=data.get("operationName"),
+        )
+
+        extensions_manager = ExtensionsManager(
+            execution_context=execution_context,
+            extensions=self.extensions,
+        )
+
+        try:
+            with extensions_manager.dispatch():
+                self._init_execution_context(
+                    execution_context, extensions_manager
+                )
+                with self.context(execution_context) as ctx:
+                    if ctx is not None:
+                        execution_context.context.update(ctx)
+                    result = self.execute(execution_context, extensions_manager)
+                return {"data": result}
+        except GraphQLError as e:
+            return {"errors": [{"message": e} for e in e.errors]}
 
 
 class BaseAsyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
     @abstractmethod
-    async def execute(self, graph: Graph, op: Operation, ctx: Dict) -> Dict:
+    async def execute(
+        self,
+        execution_context: ExecutionContext,
+        extensions_manager: ExtensionsManager,
+    ) -> Dict:
         pass
 
-    @abstractmethod
     async def dispatch(self, data: Dict) -> Dict:
-        pass
+        execution_context = create_execution_context(
+            query=data["query"],
+            variables=data.get("variables"),
+            operation_name=data.get("operationName"),
+        )
+
+        extensions_manager = ExtensionsManager(
+            execution_context=execution_context,
+            extensions=self.extensions,
+        )
+
+        try:
+            with extensions_manager.dispatch():
+                self._init_execution_context(
+                    execution_context, extensions_manager
+                )
+                with self.context(execution_context) as ctx:
+                    if ctx is not None:
+                        execution_context.context.update(ctx)
+                    result = await self.execute(
+                        execution_context, extensions_manager
+                    )
+                return {"data": result}
+        except GraphQLError as e:
+            return {"errors": [{"message": e} for e in e.errors]}
 
 
 class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
@@ -157,33 +248,64 @@ class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
     def introspection_cls(self) -> Type[BaseFederatedGraphQLIntrospection]:
         return FederatedGraphQLIntrospection
 
-    def execute(self, graph: Graph, op: Operation, ctx: Optional[Dict]) -> Dict:
-        if ctx is None:
-            ctx = {}
+    def execute(
+        self,
+        execution_context: ExecutionContext,
+        extensions_manager: ExtensionsManager,
+    ) -> Dict:
+        execution_context = cast(ExecutionContextFinal, execution_context)
 
-        stripped_query = _process_query(graph, op.query)
-        if "_service" in stripped_query.fields_map:
-            ctx["__sdl__"] = print_sdl(
-                self.query_graph,
-                self.mutation_graph,
-                self.federation_version,
-            )
+        with extensions_manager.validation():
+            if self.validation and execution_context.errors is None:
+                execution_context.errors = _run_validation(
+                    execution_context.graph,
+                    execution_context.query,
+                    execution_context.validators,
+                )
 
-        result = self.engine.execute(graph, stripped_query, ctx, op)
-        assert isinstance(result, Proxy)
-        type_name = _type_names[op.type]
-        return DenormalizeGraphQL(graph, result, type_name).process(op.query)
+        if execution_context.errors:
+            raise GraphQLError(errors=execution_context.errors)
+
+        with extensions_manager.execution():
+            if "_service" in execution_context.query.fields_map:
+                execution_context.context["__sdl__"] = print_sdl(
+                    self.query_graph,
+                    self.mutation_graph,
+                    self.federation_version,
+                )
+
+            result = self.engine.execute(execution_context)
+            assert isinstance(result, Proxy)
+            execution_context.result = result
+
+        return DenormalizeGraphQL(
+            execution_context.graph,
+            result,
+            execution_context.operation_type_name,
+        ).process(execution_context.query)
 
     def dispatch(self, data: Dict) -> Dict:
+        execution_context = create_execution_context(
+            query=data["query"],
+            variables=data.get("variables"),
+            operation_name=data.get("operationName"),
+        )
+
+        extensions_manager = ExtensionsManager(
+            execution_context=execution_context,
+            extensions=self.extensions,
+        )
+
         try:
-            graph, op = _switch_graph(
-                data,
-                self.query_graph,
-                self.mutation_graph,
-            )
-            with self.context(op) as ctx:
-                result = self.execute(graph, op, ctx)
-            return {"data": result}
+            with extensions_manager.dispatch():
+                self._init_execution_context(
+                    execution_context, extensions_manager
+                )
+                with self.context(execution_context) as ctx:
+                    if ctx is not None:
+                        execution_context.context.update(ctx)
+                    result = self.execute(execution_context, extensions_manager)
+                return {"data": result}
         except GraphQLError as e:
             return {"errors": [{"message": e} for e in e.errors]}
 
@@ -194,43 +316,42 @@ class AsyncFederatedGraphQLEndpoint(BaseAsyncFederatedGraphQLEndpoint):
         return AsyncFederatedGraphQLIntrospection
 
     async def execute(
-        self, graph: Graph, op: Operation, ctx: Optional[Dict]
+        self,
+        execution_context: ExecutionContext,
+        extensions_manager: ExtensionsManager,
     ) -> Dict:
-        if ctx is None:
-            ctx = {}
+        execution_context = cast(ExecutionContextFinal, execution_context)
 
-        stripped_query = _process_query(graph, op.query)
+        with extensions_manager.validation():
+            if self.validation and execution_context.errors is None:
+                execution_context.errors = _run_validation(
+                    execution_context.graph,
+                    execution_context.query,
+                    execution_context.validators,
+                )
 
-        if "_service" in stripped_query.fields_map:
-            ctx["__sdl__"] = print_sdl(
-                self.query_graph,
-                self.mutation_graph,
-                self.federation_version,
-            )
+        if execution_context.errors:
+            raise GraphQLError(errors=execution_context.errors)
 
-        coro = self.engine.execute(graph, stripped_query, ctx)
+        with extensions_manager.execution():
+            if "_service" in execution_context.query.fields_map:
+                execution_context.context["__sdl__"] = print_sdl(
+                    self.query_graph,
+                    self.mutation_graph,
+                    self.federation_version,
+                )
 
-        assert isawaitable(coro)
-        result = await coro
-        type_name = _type_names[op.type]
-        return DenormalizeGraphQL(graph, result, type_name).process(op.query)
+            coro = self.engine.execute(execution_context)
+            assert isawaitable(coro)
+            result = await coro
+            execution_context.result = result
 
-    async def dispatch(self, data: Dict) -> Dict:
-        try:
-            graph, op = _switch_graph(
-                data,
-                self.query_graph,
-                self.mutation_graph,
-            )
+        return DenormalizeGraphQL(
+            execution_context.graph,
+            result,
+            execution_context.operation_type_name,
+        ).process(execution_context.query)
 
-            with self.context(op) as ctx:
-                result = await self.execute(graph, op, ctx)
-            return {"data": result}
-        except GraphQLError as e:
-            return {"errors": [{"message": e} for e in e.errors]}
-
-
-class AsyncBatchFederatedGraphQLEndpoint(AsyncFederatedGraphQLEndpoint):
     @overload
     async def dispatch(self, data: List[Dict]) -> List[Dict]:
         ...
@@ -248,3 +369,9 @@ class AsyncBatchFederatedGraphQLEndpoint(AsyncFederatedGraphQLEndpoint):
             )
 
         return await super().dispatch(data)
+
+
+class AsyncBatchFederatedGraphQLEndpoint(AsyncFederatedGraphQLEndpoint):
+    def __init__(self, *args: Any, **kwargs: Any):
+        kwargs["batching"] = True
+        super().__init__(*args, **kwargs)

--- a/hiku/operation.py
+++ b/hiku/operation.py
@@ -1,0 +1,33 @@
+import enum
+
+from typing import Optional
+
+from graphql.language import ast
+from hiku.query import Node
+
+
+class OperationType(enum.Enum):
+    """Enumerates GraphQL operation types"""
+
+    #: query operation
+    QUERY = ast.OperationType.QUERY
+    #: mutation operation
+    MUTATION = ast.OperationType.MUTATION
+    #: subscription operation
+    SUBSCRIPTION = ast.OperationType.SUBSCRIPTION
+
+
+class Operation:
+    """Represents requested GraphQL operation"""
+
+    __slots__ = ("type", "query", "name")
+
+    def __init__(
+        self, type_: OperationType, query: Node, name: Optional[str] = None
+    ):
+        #: type of the operation
+        self.type = type_
+        #: operation's query
+        self.query = query
+        #: optional name of the operation
+        self.name = name

--- a/hiku/operation.py
+++ b/hiku/operation.py
@@ -1,9 +1,11 @@
 import enum
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from graphql.language import ast
-from hiku.query import Node
+
+if TYPE_CHECKING:
+    from hiku.query import Node
 
 
 class OperationType(enum.Enum):
@@ -23,7 +25,7 @@ class Operation:
     __slots__ = ("type", "query", "name")
 
     def __init__(
-        self, type_: OperationType, query: Node, name: Optional[str] = None
+        self, type_: OperationType, query: "Node", name: Optional[str] = None
     ):
         #: type of the operation
         self.type = type_

--- a/hiku/query.py
+++ b/hiku/query.py
@@ -133,6 +133,10 @@ class FieldBase(Base):
         else:
             return self.name
 
+    # TODO: test this hash
+    def __hash__(self) -> int:
+        return hash(self.index_key)
+
 
 class Field(FieldBase):
     """Represents a field of the node
@@ -252,6 +256,9 @@ class Node(Base):
     def accept(self, visitor: "QueryVisitor") -> t.Any:
         return visitor.visit_node(self)
 
+    def __hash__(self) -> int:
+        return hash(tuple(self.fields)) + hash(tuple(self.fragments))
+
 
 class Fragment(Base):
     __attrs__ = ("type_name", "node")
@@ -262,6 +269,9 @@ class Fragment(Base):
 
     def accept(self, visitor: "QueryVisitor") -> t.Any:
         return visitor.visit_fragment(self)
+
+    def __hash__(self) -> int:
+        return hash(self.type_name) + hash(self.node)
 
 
 KeyT = t.Tuple[str, t.Optional[str], t.Optional[str]]

--- a/hiku/readers/graphql.py
+++ b/hiku/readers/graphql.py
@@ -484,7 +484,7 @@ def read(
     .. code-block:: python
 
         query = read('{ foo bar }')
-        result = engine.execute(graph, query)
+        result = engine.execute(query, graph)
 
     :param str src: GraphQL query
     :param dict variables: query variables
@@ -515,7 +515,7 @@ def read_operation(
 
         op = read_operation('{ foo bar }')
         if op.type is OperationType.QUERY:
-            result = engine.execute(query_graph, op.query)
+            result = engine.execute(op.query, query_graph)
 
     :return: :py:class:`Operation`
     """

--- a/hiku/readers/graphql.py
+++ b/hiku/readers/graphql.py
@@ -484,7 +484,7 @@ def read(
     .. code-block:: python
 
         query = read('{ foo bar }')
-        result = engine.execute(query, graph)
+        result = engine.execute(graph, query)
 
     :param str src: GraphQL query
     :param dict variables: query variables

--- a/hiku/readers/graphql.py
+++ b/hiku/readers/graphql.py
@@ -1,4 +1,3 @@
-import enum
 from collections import defaultdict
 
 from typing import (
@@ -11,22 +10,18 @@ from typing import (
     cast,
     Any,
     Set,
-    Callable,
 )
-from functools import lru_cache
 
 from graphql.language import ast
 from graphql.language.parser import parse
+from hiku.utils import ImmutableDict
 
 from ..directives import (
     Cached,
     Directive,
 )
+from ..operation import Operation, OperationType
 from ..query import FieldOrLink, Fragment, Node, Field, Link, merge
-from ..telemetry.prometheus import (
-    QUERY_CACHE_HITS,
-    QUERY_CACHE_MISSES,
-)
 
 
 def parse_query(src: str) -> ast.DocumentNode:
@@ -36,29 +31,6 @@ def parse_query(src: str) -> ast.DocumentNode:
     :return: :py:class:`ast.DocumentNode`
     """
     return parse(src)
-
-
-def wrap_metrics(cached_parser: Callable) -> Callable:
-    def wrapper(*args: Any, **kwargs: Any) -> ast.DocumentNode:
-        ast = cached_parser(*args, **kwargs)
-        info = cached_parser.cache_info()  # type: ignore
-        QUERY_CACHE_HITS.set(info.hits)
-        QUERY_CACHE_MISSES.set(info.misses)
-        return ast
-
-    return wrapper
-
-
-def setup_query_cache(
-    size: int = 128,
-) -> None:
-    """Sets up lru cache for the ast parsing.
-
-    :param int size: Maximum size of the cache
-    """
-    global parse_query
-    parse_query = lru_cache(maxsize=size)(parse_query)
-    parse_query = wrap_metrics(parse_query)
 
 
 class NodeVisitor:
@@ -494,6 +466,12 @@ class GraphQLTransformer(SelectionSetVisitMixin, NodeVisitor):
         return merge([node])
 
 
+def get_operation(
+    doc: ast.DocumentNode, operation_name: Optional[str]
+) -> ast.OperationDefinitionNode:
+    return OperationGetter.get(doc, operation_name=operation_name)
+
+
 def read(
     src: str,
     variables: Optional[Dict] = None,
@@ -514,7 +492,7 @@ def read(
     :return: :py:class:`hiku.query.Node`, ready to execute query object
     """
     doc = parse_query(src)
-    op = OperationGetter.get(doc, operation_name=operation_name)
+    op = get_operation(doc, operation_name=operation_name)
     if op.operation is not ast.OperationType.QUERY:
         raise TypeError(
             'Only "query" operations are supported, '
@@ -524,36 +502,9 @@ def read(
     return GraphQLTransformer.transform(doc, op, variables)
 
 
-class OperationType(enum.Enum):
-    """Enumerates GraphQL operation types"""
-
-    #: query operation
-    QUERY = ast.OperationType.QUERY
-    #: mutation operation
-    MUTATION = ast.OperationType.MUTATION
-    #: subscription operation
-    SUBSCRIPTION = ast.OperationType.SUBSCRIPTION
-
-
-class Operation:
-    """Represents requested GraphQL operation"""
-
-    __slots__ = ("type", "query", "name")
-
-    def __init__(
-        self, type_: OperationType, query: Node, name: Optional[str] = None
-    ):
-        #: type of the operation
-        self.type = type_
-        #: operation's query
-        self.query = query
-        #: optional name of the operation
-        self.name = name
-
-
 def read_operation(
-    src: str,
-    variables: Optional[Dict] = None,
+    src: Union[str, ast.DocumentNode],
+    variables: Optional[Union[Dict, ImmutableDict]] = None,
     operation_name: Optional[str] = None,
 ) -> Operation:
     """Reads an operation from the GraphQL document
@@ -566,13 +517,16 @@ def read_operation(
         if op.type is OperationType.QUERY:
             result = engine.execute(query_graph, op.query)
 
-    :param str src: GraphQL document
-    :param dict variables: query variables
-    :param str operation_name: Name of the operation to execute
     :return: :py:class:`Operation`
     """
-    doc = parse_query(src)
-    op = OperationGetter.get(doc, operation_name=operation_name)
+    if isinstance(src, str):
+        doc = parse_query(src)
+    elif isinstance(src, ast.DocumentNode):
+        doc = src
+    else:
+        raise TypeError("Unsupported type: {}".format(type(src)))
+
+    op = get_operation(doc, operation_name=operation_name)
     query = GraphQLTransformer.transform(doc, op, variables)
     type_ = cast(
         Optional[OperationType],

--- a/hiku/readers/protobuf.py
+++ b/hiku/readers/protobuf.py
@@ -66,7 +66,7 @@ def read(data):
 
         query = read(bin_query)  # reading binary message
 
-        result = engine.execute(query, graph)
+        result = engine.execute(graph, query)
 
     :param bytes data: binary message representation
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/readers/protobuf.py
+++ b/hiku/readers/protobuf.py
@@ -66,7 +66,7 @@ def read(data):
 
         query = read(bin_query)  # reading binary message
 
-        result = engine.execute_query(graph, query)
+        result = engine.execute(query, graph)
 
     :param bytes data: binary message representation
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/readers/protobuf.py
+++ b/hiku/readers/protobuf.py
@@ -66,7 +66,7 @@ def read(data):
 
         query = read(bin_query)  # reading binary message
 
-        result = engine.execute(graph, query)
+        result = engine.execute_query(graph, query)
 
     :param bytes data: binary message representation
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/readers/simple.py
+++ b/hiku/readers/simple.py
@@ -88,7 +88,7 @@ def read(src):
     .. code-block:: python
 
         query = read('[{(:characters {:limit 100}) [:name]}]')
-        result = engine.execute(query, graph)
+        result = engine.execute(graph, query)
 
     :param str src: EDN-encoded data structure
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/readers/simple.py
+++ b/hiku/readers/simple.py
@@ -88,7 +88,7 @@ def read(src):
     .. code-block:: python
 
         query = read('[{(:characters {:limit 100}) [:name]}]')
-        result = engine.execute(graph, query)
+        result = engine.execute_query(graph, query)
 
     :param str src: EDN-encoded data structure
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/readers/simple.py
+++ b/hiku/readers/simple.py
@@ -88,7 +88,7 @@ def read(src):
     .. code-block:: python
 
         query = read('[{(:characters {:limit 100}) [:name]}]')
-        result = engine.execute_query(graph, query)
+        result = engine.execute(query, graph)
 
     :param str src: EDN-encoded data structure
     :return: :py:class:`hiku.query.Node`, ready to execute query object

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -245,7 +245,7 @@ def denormalize(graph: Graph, result: Proxy) -> t.Dict:
     .. code-block:: python
 
         query = hiku.readers.simple.read('[:foo]')
-        norm_result = hiku_engine.execute(query, graph)
+        norm_result = hiku_engine.execute(graph, query)
         result = hiku.result.denormalize(graph, norm_result)
         assert result == {'foo': 'value'}
 

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -245,7 +245,7 @@ def denormalize(graph: Graph, result: Proxy) -> t.Dict:
     .. code-block:: python
 
         query = hiku.readers.simple.read('[:foo]')
-        norm_result = hiku_engine.execute_query(graph, query)
+        norm_result = hiku_engine.execute(query, graph)
         result = hiku.result.denormalize(graph, norm_result)
         assert result == {'foo': 'value'}
 

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -245,7 +245,7 @@ def denormalize(graph: Graph, result: Proxy) -> t.Dict:
     .. code-block:: python
 
         query = hiku.readers.simple.read('[:foo]')
-        norm_result = hiku_engine.execute(graph, query)
+        norm_result = hiku_engine.execute_query(graph, query)
         result = hiku.result.denormalize(graph, norm_result)
         assert result == {'foo': 'value'}
 

--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -324,6 +324,9 @@ class _RecordFieldsValidator(QueryVisitor):
         self._errors = errors
 
     def visit_field(self, obj: QueryField) -> None:
+        if obj.name == "__typename":
+            return
+
         if obj.name not in self._field_types:
             self._errors.report('Unknown field name "{}"'.format(obj.name))
         elif obj.options is not None:

--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -354,7 +354,7 @@ def _field_eq(a: FieldBase, b: FieldBase) -> bool:
     return a.name == b.name and a.options == b.options
 
 
-class QueryValidator(QueryVisitor):
+class DefaultQueryValidator(QueryVisitor):
     """
     Validate query against graph.
 
@@ -529,6 +529,6 @@ class QueryValidator(QueryVisitor):
 
 
 def validate(graph: Graph, query: QueryNode) -> t.List[str]:
-    query_validator = QueryValidator(graph)
+    query_validator = DefaultQueryValidator(graph)
     query_validator.visit(query)
     return query_validator.errors.list

--- a/pdm.lock
+++ b/pdm.lock
@@ -51,8 +51,8 @@ summary = "Read/rewrite/write Python ASTs"
 
 [[package]]
 name = "async-timeout"
-version = "4.0.2"
-requires_python = ">=3.6"
+version = "4.0.3"
+requires_python = ">=3.7"
 summary = "Timeout context manager for asyncio programs"
 dependencies = [
     "typing-extensions>=3.6.5; python_version < \"3.8\"",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
 
@@ -121,7 +121,7 @@ summary = "The Real First Universal Charset Detector. Open, modern and actively 
 
 [[package]]
 name = "click"
-version = "8.1.4"
+version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
 dependencies = [
@@ -160,7 +160,7 @@ summary = "Docutils -- Python Documentation Utilities"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 requires_python = ">=3.7"
 summary = "Backport of PEP 654 (exception groups)"
 
@@ -307,17 +307,17 @@ summary = "Core utilities for Python packages"
 
 [[package]]
 name = "pathspec"
-version = "0.11.1"
+version = "0.11.2"
 requires_python = ">=3.7"
 summary = "Utility library for gitignore style pattern matching of file paths."
 
 [[package]]
 name = "platformdirs"
-version = "3.8.1"
+version = "3.10.0"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 dependencies = [
-    "typing-extensions>=4.6.3; python_version < \"3.8\"",
+    "typing-extensions>=4.7.1; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -343,7 +343,7 @@ summary = "Protocol Buffers"
 
 [[package]]
 name = "psycopg2-binary"
-version = "2.9.6"
+version = "2.9.7"
 requires_python = ">=3.6"
 summary = "psycopg2 - Python-PostgreSQL Database Adapter"
 
@@ -376,13 +376,13 @@ summary = "Python package providing assets from https://github.com/Kozea/pygal.j
 
 [[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 requires_python = ">=3.7"
 summary = "Pygments is a syntax highlighting package written in Python."
 
 [[package]]
 name = "pytest"
-version = "7.4.0"
+version = "7.4.1"
 requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.0"
+version = "0.21.1"
 requires_python = ">=3.7"
 summary = "Pytest support for asyncio"
 dependencies = [
@@ -461,6 +461,15 @@ dependencies = [
     "charset-normalizer<4,>=2",
     "idna<4,>=2.5",
     "urllib3<3,>=1.21.1",
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "1.30.0"
+summary = "Python client for Sentry (https://sentry.io)"
+dependencies = [
+    "certifi",
+    "urllib3>=1.26.11; python_version >= \"3.6\"",
 ]
 
 [[package]]
@@ -575,7 +584,7 @@ summary = "Backported and Experimental Type Hints for Python 3.7+"
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "2.0.4"
 requires_python = ">=3.7"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 
@@ -609,7 +618,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "dev", "docs", "examples", "test"]
-content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98ce0cf748"
+content_hash = "sha256:1812cd17ce6f404494bb00a67dd519b32adeb75fff2ce1f5e7a539bd9c5ae785"
 
 [metadata.files]
 "aiohttp 3.8.4" = [
@@ -717,9 +726,9 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/5a/21/75b771132fee241dfe601d39ade629548a9626d1d39f333fde31bc46febe/astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
     {url = "https://files.pythonhosted.org/packages/c3/88/97eef84f48fa04fbd6750e62dcceafba6c63c81b7ac1420856c8dcc0a3f9/astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
 ]
-"async-timeout 4.0.2" = [
-    {url = "https://files.pythonhosted.org/packages/54/6e/9678f7b2993537452710ffb1750c62d2c26df438aa621ad5fa9d1507a43a/async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
-    {url = "https://files.pythonhosted.org/packages/d6/c1/8991e7c5385b897b8c020cdaad718c5b087a6626d1d11a23e1ea87e325a7/async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+"async-timeout 4.0.3" = [
+    {url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
+    {url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
 ]
 "asyncpg 0.28.0" = [
     {url = "https://files.pythonhosted.org/packages/07/20/4c6f1215cc7e65a363a2eba4d44f846341c3912a8c8543b68f3cbc425c7a/asyncpg-0.28.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0c402745185414e4c204a02daca3d22d732b37359db4d2e705172324e2d94e85"},
@@ -802,9 +811,9 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/eb/a5/17b40bfd9b607b69fa726b0b3a473d14b093dcd5191ea1a1dd664eccfee3/black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
     {url = "https://files.pythonhosted.org/packages/fd/5b/fc2d7922c1a6bb49458d424b5be71d251f2d0dc97be9534e35d171bdc653/black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
 ]
-"certifi 2023.5.7" = [
-    {url = "https://files.pythonhosted.org/packages/93/71/752f7a4dd4c20d6b12341ed1732368546bc0ca9866139fe812f6009d9ac7/certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
-    {url = "https://files.pythonhosted.org/packages/9d/19/59961b522e6757f0c9097e4493fa906031b95b3ebe9360b2c3083561a6b4/certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+"certifi 2023.7.22" = [
+    {url = "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {url = "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 "charset-normalizer 3.2.0" = [
     {url = "https://files.pythonhosted.org/packages/08/f7/3f36bb1d0d74846155c7e3bf1477004c41243bb510f9082e785809787735/charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
@@ -883,9 +892,9 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/f9/0d/514be8597d7a96243e5467a37d337b9399cec117a513fcf9328405d911c0/charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
     {url = "https://files.pythonhosted.org/packages/fd/17/0a1dba835ec37a3cc025f5c49653effb23f8cd391dea5e60a5696d639a92/charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
 ]
-"click 8.1.4" = [
-    {url = "https://files.pythonhosted.org/packages/77/88/b0cc5fe95c31c301e9823ea9b028f669c0dcfa205ff71111037a5ed4892c/click-8.1.4.tar.gz", hash = "sha256:b97d0c74955da062a7d4ef92fadb583806a585b2ea81958a81bd72726cbb8e37"},
-    {url = "https://files.pythonhosted.org/packages/f9/a6/dc327484918f1656cc9fcebebe77efcfc0ef0d447fa925a8760ee55abe0e/click-8.1.4-py3-none-any.whl", hash = "sha256:2739815aaa5d2c986a88f1e9230c55e17f0caad3d958a5e13ad0797c166db9e3"},
+"click 8.1.7" = [
+    {url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 "colorama 0.4.6" = [
     {url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -957,9 +966,9 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/4c/17/559b4d020f4b46e0287a2eddf2d8ebf76318fd3bd495f1625414b052fdc9/docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
     {url = "https://files.pythonhosted.org/packages/4c/5e/6003a0d1f37725ec2ebd4046b657abb9372202655f96e76795dca8c0063c/docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
 ]
-"exceptiongroup 1.1.2" = [
-    {url = "https://files.pythonhosted.org/packages/55/09/5d2079ecab0ca483e527a1707a483562bdc17abf829d3e73f0c1a73b61c7/exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
-    {url = "https://files.pythonhosted.org/packages/fe/17/f43b7c9ccf399d72038042ee72785c305f6c6fdc6231942f8ab99d995742/exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
+"exceptiongroup 1.1.3" = [
+    {url = "https://files.pythonhosted.org/packages/ad/83/b71e58666f156a39fb29417e4c8ca4bc7400c0dd4ed9e8842ab54dc8c344/exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {url = "https://files.pythonhosted.org/packages/c2/e1/5561ad26f99b7779c28356f73f69a8b468ef491d0f6adf20d7ed0ac98ec1/exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 "faker 18.13.0" = [
     {url = "https://files.pythonhosted.org/packages/3b/5f/949fa58c4bac00b6d5e74eef05c2c7c2efc6bea3d56cd3adb257faf0bf8b/Faker-18.13.0-py3-none-any.whl", hash = "sha256:801d1a2d71f1fc54d332de2ab19de7452454309937233ea2f7485402882d67b3"},
@@ -1054,6 +1063,7 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/f8/39/e5143e7ec70939d2076c1165ae9d4a3815597019c4d797b7f959cf778600/graphql_core-3.2.3-py3-none-any.whl", hash = "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"},
 ]
 "greenlet 2.0.2" = [
+    {url = "https://files.pythonhosted.org/packages/03/1a/dae7e4abc978e3eff4b8e90e76fb6619ba38d3cabac5f10131880fc03091/greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
     {url = "https://files.pythonhosted.org/packages/07/ef/6bfa2ea34f76dea02833d66d28ae7cf4729ddab74ee93ee069c7f1d47c4f/greenlet-2.0.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b"},
     {url = "https://files.pythonhosted.org/packages/08/b1/0615df6393464d6819040124eb7bdff6b682f206a464b4537964819dcab4/greenlet-2.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dd11f291565a81d71dab10b7033395b7a3a5456e637cf997a6f33ebdf06f8db"},
     {url = "https://files.pythonhosted.org/packages/09/57/5fdd37939e0989a756a32d0a838409b68d1c5d348115e9c697f42ee4f87d/greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
@@ -1067,8 +1077,10 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/1f/42/95800f165d20fb8269fe6a3ac494649718ede074b1d8a78f58ee2ebda27a/greenlet-2.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33"},
     {url = "https://files.pythonhosted.org/packages/20/28/c93ffaa75f3c907cd010bf44c5c18c7f8f4bb2409146bd67d538163e33b8/greenlet-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8"},
     {url = "https://files.pythonhosted.org/packages/29/c4/fe82cb9ff1bffc52a3832e35fa49cce63e5d366808179153ee879ce47cc9/greenlet-2.0.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9d14b83fab60d5e8abe587d51c75b252bcc21683f24699ada8fb275d7712f5a9"},
+    {url = "https://files.pythonhosted.org/packages/34/27/ca6f6deccf2bf7dce5c50953d354d22743f9e2bbce36815f31966687a4d1/greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
     {url = "https://files.pythonhosted.org/packages/37/b9/3ebd606768bee3ef2198fe6d5e7c6c3af42ad3e06b56c1d0a89c56faba2a/greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
     {url = "https://files.pythonhosted.org/packages/3a/69/a6d3d7abd0f36438ff5fab52572fd107966939d59ef9b8309263ab89f607/greenlet-2.0.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6"},
+    {url = "https://files.pythonhosted.org/packages/3f/1a/1a48b85490d93af5c577e6ab4d032ee3fe85c4c6d8656376f28d6d403fb1/greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
     {url = "https://files.pythonhosted.org/packages/42/d0/285b81442d8552b1ae6a2ff38caeec94ab90507c9740da718189416e8e6e/greenlet-2.0.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d"},
     {url = "https://files.pythonhosted.org/packages/43/81/e0a656e3a417b172f834ba5a08dde02b55fd249416c1e933d62ffb6734d0/greenlet-2.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2780572ec463d44c1d3ae850239508dbeb9fed38e294c68d19a24d925d9223ca"},
     {url = "https://files.pythonhosted.org/packages/49/b8/3ee1723978245e6f0c087908689f424876803ec05555400681240ab2ab33/greenlet-2.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b"},
@@ -1079,6 +1091,7 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/54/ce/3a589ec27bd5de97707d2a193716bbe412ccbdb1479f0c3f990789c8fa8c/greenlet-2.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7"},
     {url = "https://files.pythonhosted.org/packages/57/a8/079c59b8f5406957224f4f4176e9827508d555beba6d8635787d694226d1/greenlet-2.0.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43"},
     {url = "https://files.pythonhosted.org/packages/5a/30/5eab5cbb99263c7d8305657587381c84da2a71fddb07dd5efbfaeecf7264/greenlet-2.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937e9020b514ceedb9c830c55d5c9872abc90f4b5862f89c0887033ae33c6f73"},
+    {url = "https://files.pythonhosted.org/packages/5d/34/d15e394dd41d84e40d1ef421716a939ad8fb65f010be9480f7a3b9e19bcd/greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
     {url = "https://files.pythonhosted.org/packages/6a/3d/77bd8dd7dd0b872eac87f1edf6fcd94d9d7666befb706ae3a08ed25fbea7/greenlet-2.0.2-cp36-cp36m-win32.whl", hash = "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9"},
     {url = "https://files.pythonhosted.org/packages/6b/2f/1cb3f376df561c95cb61b199676f51251f991699e325a2aa5e12693d10b8/greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
     {url = "https://files.pythonhosted.org/packages/6b/cd/84301cdf80360571f6aa77ac096f867ba98094fec2cb93e69c93d996b8f8/greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
@@ -1307,13 +1320,13 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
     {url = "https://files.pythonhosted.org/packages/b9/6c/7c6658d258d7971c5eb0d9b69fa9265879ec9a9158031206d47800ae2213/packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
-"pathspec 0.11.1" = [
-    {url = "https://files.pythonhosted.org/packages/95/60/d93628975242cc515ab2b8f5b2fc831d8be2eff32f5a1be4776d49305d13/pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
-    {url = "https://files.pythonhosted.org/packages/be/c8/551a803a6ebb174ec1c124e68b449b98a0961f0b737def601e3c1fbb4cfd/pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+"pathspec 0.11.2" = [
+    {url = "https://files.pythonhosted.org/packages/a0/2a/bd167cdf116d4f3539caaa4c332752aac0b3a0cc0174cdb302ee68933e81/pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
+    {url = "https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
 ]
-"platformdirs 3.8.1" = [
-    {url = "https://files.pythonhosted.org/packages/92/38/3dd18a282991c004851ea1f0953105a186cfc691eee2792778ac2ca060f8/platformdirs-3.8.1.tar.gz", hash = "sha256:f87ca4fcff7d2b0f81c6a748a77973d7af0f4d526f98f308477c3c436c74d528"},
-    {url = "https://files.pythonhosted.org/packages/9e/d8/563a9fc17153c588c8c2042d2f0f84a89057cdb1c30270f589c88b42d62c/platformdirs-3.8.1-py3-none-any.whl", hash = "sha256:cec7b889196b9144d088e4c57d9ceef7374f6c39694ad1577a0aab50d27ea28c"},
+"platformdirs 3.10.0" = [
+    {url = "https://files.pythonhosted.org/packages/14/51/fe5a0d6ea589f0d4a1b97824fb518962ad48b27cd346dcdfa2405187997a/platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
+    {url = "https://files.pythonhosted.org/packages/dc/99/c922839819f5d00d78b3a1057b5ceee3123c69b2216e776ddcb5a4c265ff/platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
 ]
 "pluggy 1.2.0" = [
     {url = "https://files.pythonhosted.org/packages/51/32/4a79112b8b87b21450b066e102d6608907f4c885ed7b04c3fdb085d4d6ae/pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
@@ -1347,69 +1360,67 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/ef/d4/765a106ca96d487f94f3c99e46b399218f53735628c3b2d759a832e2adab/protobuf-3.20.3-cp37-cp37m-win32.whl", hash = "sha256:b6cc7ba72a8850621bfec987cb72623e703b7fe2b9127a161ce61e61558ad905"},
     {url = "https://files.pythonhosted.org/packages/fe/8f/d9db035740002d61b4140aaef53a8bac7e316b18ec8744eb6c1fcf83c310/protobuf-3.20.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4"},
 ]
-"psycopg2-binary 2.9.6" = [
-    {url = "https://files.pythonhosted.org/packages/01/76/512f0a878dd900902ed818156baccaf94c05d0450534f7b4f714932e3d7e/psycopg2_binary-2.9.6-cp311-cp311-win32.whl", hash = "sha256:1876843d8e31c89c399e31b97d4b9725a3575bb9c2af92038464231ec40f9edb"},
-    {url = "https://files.pythonhosted.org/packages/0a/4a/6134e27e1deba089e45a9a328802ec04f47f74621f5e82eeab8828c83ded/psycopg2_binary-2.9.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:964b4dfb7c1c1965ac4c1978b0f755cc4bd698e8aa2b7667c575fb5f04ebe06b"},
-    {url = "https://files.pythonhosted.org/packages/14/2b/92dd9b92cbc7060978e01edaf240eeab8d4a0e81baf953fc1840ab0c0cd7/psycopg2_binary-2.9.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf4499e0a83b7b7edcb8dabecbd8501d0d3a5ef66457200f77bde3d210d5debb"},
-    {url = "https://files.pythonhosted.org/packages/1e/ec/8502015f712c326d3908b8c01b340aa02e33b61b36ffbe789ebffa2bc9e8/psycopg2_binary-2.9.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfb13af3c5dd3a9588000910178de17010ebcccd37b4f9794b00595e3a8ddad3"},
-    {url = "https://files.pythonhosted.org/packages/26/40/c86e30a4c7c72b76b8ab6663568667d07f654770e45f09f022bfec2c2bd5/psycopg2_binary-2.9.6-cp311-cp311-win_amd64.whl", hash = "sha256:b4b24f75d16a89cc6b4cdff0eb6a910a966ecd476d1e73f7ce5985ff1328e9a6"},
-    {url = "https://files.pythonhosted.org/packages/26/8c/95a22fe085e47e6302e7d51c1b3b20fe634d3bb8ff8ebc5db15eeaf24d0f/psycopg2_binary-2.9.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7f0438fa20fb6c7e202863e0d5ab02c246d35efb1d164e052f2f3bfe2b152bd0"},
-    {url = "https://files.pythonhosted.org/packages/2a/2d/0009542ac8ec9136795dc83473eeaca8b059fe903a75ff158b6c8eba2a47/psycopg2_binary-2.9.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38601cbbfe600362c43714482f43b7c110b20cb0f8172422c616b09b85a750c5"},
-    {url = "https://files.pythonhosted.org/packages/2a/73/51ee20b1e3bcd91b01e9773bbd12c9c75434021664a10dfdfcb648519d14/psycopg2_binary-2.9.6-cp36-cp36m-win_amd64.whl", hash = "sha256:0d236c2825fa656a2d98bbb0e52370a2e852e5a0ec45fc4f402977313329174d"},
-    {url = "https://files.pythonhosted.org/packages/2f/86/60972984855fe535f2f4b4bf614d716080abfb7ae8c4ef59e728ce048c76/psycopg2_binary-2.9.6-cp36-cp36m-win32.whl", hash = "sha256:498807b927ca2510baea1b05cc91d7da4718a0f53cb766c154c417a39f1820a0"},
-    {url = "https://files.pythonhosted.org/packages/34/a8/ba8ac3a5af59876304ea504788cbe09680c6b6fe2e4d0cfe9fe23940e46c/psycopg2_binary-2.9.6-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30637a20623e2a2eacc420059be11527f4458ef54352d870b8181a4c3020ae6b"},
-    {url = "https://files.pythonhosted.org/packages/34/d9/835fce2b1e3986eac8dcaf291509e1e199df1be4fea48748992159a9bfbc/psycopg2_binary-2.9.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7a40c00dbe17c0af5bdd55aafd6ff6679f94a9be9513a4c7e071baf3d7d22a70"},
-    {url = "https://files.pythonhosted.org/packages/35/bb/f9247d5eb67382b323d188e6f0c5cb515138978dc7dd2e22fa85d1866824/psycopg2_binary-2.9.6-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:0892ef645c2fabb0c75ec32d79f4252542d0caec1d5d949630e7d242ca4681a3"},
-    {url = "https://files.pythonhosted.org/packages/37/23/f2d33b6925973c152923509c7eac9fc8e7bc5c92716a13e780076b2c6c71/psycopg2_binary-2.9.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e0f754d27fddcfd74006455b6e04e6705d6c31a612ec69ddc040a5468e44b4e"},
-    {url = "https://files.pythonhosted.org/packages/38/94/3a2587f15516deed871e228e15c450917e02d6bb461e14dce6e794bfc7a7/psycopg2_binary-2.9.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:65c07febd1936d63bfde78948b76cd4c2a411572a44ac50719ead41947d0f26b"},
-    {url = "https://files.pythonhosted.org/packages/3d/4a/7d093adb422d57fdbca6a70852af4cc2b8f1eaf7bcfb713065e881558bb7/psycopg2_binary-2.9.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4c727b597c6444a16e9119386b59388f8a424223302d0c06c676ec8b4bc1f963"},
-    {url = "https://files.pythonhosted.org/packages/42/1c/052e24154767445334601f08a7c4c8c165f48402604aa51efcabd4bedb40/psycopg2_binary-2.9.6-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71f14375d6f73b62800530b581aed3ada394039877818b2d5f7fc77e3bb6894d"},
-    {url = "https://files.pythonhosted.org/packages/44/06/6de819cb8604ad884aefe8d12980f53788fc08c4de8ea3ff1b3039746449/psycopg2_binary-2.9.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae102a98c547ee2288637af07393dd33f440c25e5cd79556b04e3fca13325e5f"},
-    {url = "https://files.pythonhosted.org/packages/5b/6f/b25708056f623e107e50c255d770dba42729f9ad1affbeba32b804b9f20d/psycopg2_binary-2.9.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe9dc0a884a8848075e576c1de0290d85a533a9f6e9c4e564f19adf8f6e54a7"},
-    {url = "https://files.pythonhosted.org/packages/5d/67/73f4829773c1c7f90cd3d635732a436f31db64cad5849a5ddd88c187568b/psycopg2_binary-2.9.6-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:4ac30da8b4f57187dbf449294d23b808f8f53cad6b1fc3623fa8a6c11d176dd0"},
-    {url = "https://files.pythonhosted.org/packages/65/6d/4b03140b6cf75a265187634db7de290719e69306fe535d33560b277a754d/psycopg2_binary-2.9.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8338a271cb71d8da40b023a35d9c1e919eba6cbd8fa20a54b748a332c355d896"},
-    {url = "https://files.pythonhosted.org/packages/65/dc/efec61db1ab80314e09874035388812379d0b0f083dcaa6cc98f10fb94cb/psycopg2_binary-2.9.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:af335bac6b666cc6aea16f11d486c3b794029d9df029967f9938a4bed59b6a19"},
-    {url = "https://files.pythonhosted.org/packages/67/3d/4ab532a0b91a228d42fe6f4bd62384ae852fad92e195c6f78013045eb9ba/psycopg2_binary-2.9.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0645376d399bfd64da57148694d78e1f431b1e1ee1054872a5713125681cf1be"},
-    {url = "https://files.pythonhosted.org/packages/68/88/0ea86f9d4b845b6da22890586efeeab9ba56674474ad58d0f246e46de0a6/psycopg2_binary-2.9.6-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dfa74c903a3c1f0d9b1c7e7b53ed2d929a4910e272add6700c38f365a6002820"},
-    {url = "https://files.pythonhosted.org/packages/69/60/a24e7805b5eba1bef11f20aeed09189cf3bece10c61b8b61c0a30aff91d0/psycopg2_binary-2.9.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84d2222e61f313c4848ff05353653bf5f5cf6ce34df540e4274516880d9c3763"},
-    {url = "https://files.pythonhosted.org/packages/6e/46/c0c556bdc793c0bb0b3af31e3d0a46e68e58ae1cbb7ede2daf2d7139137e/psycopg2_binary-2.9.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b83456c2d4979e08ff56180a76429263ea254c3f6552cd14ada95cff1dec9bb8"},
-    {url = "https://files.pythonhosted.org/packages/75/e7/20de803d3e2eef1929e74e8521df12ef220d57008e563c9dbde2112f2e38/psycopg2_binary-2.9.6-cp39-cp39-win32.whl", hash = "sha256:c3dba7dab16709a33a847e5cd756767271697041fbe3fe97c215b1fc1f5c9848"},
-    {url = "https://files.pythonhosted.org/packages/77/db/af19b6fc482b563ec0141ff562f915b5760ac8201b3a6a2484c5a604fd2e/psycopg2_binary-2.9.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8a6979cf527e2603d349a91060f428bcb135aea2be3201dff794813256c274f1"},
-    {url = "https://files.pythonhosted.org/packages/79/26/7a246105af93fa418e8c45a23c9b45613a123e5414fa451b3bf33f2a0c78/psycopg2_binary-2.9.6-cp37-cp37m-win_amd64.whl", hash = "sha256:51537e3d299be0db9137b321dfb6a5022caaab275775680e0c3d281feefaca6b"},
-    {url = "https://files.pythonhosted.org/packages/7e/be/2c09bf908253259a7ddab038907d0bc9080087802a96ff07ac63fcda4866/psycopg2_binary-2.9.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d4e6036decf4b72d6425d5b29bbd3e8f0ff1059cda7ac7b96d6ac5ed34ffbacd"},
-    {url = "https://files.pythonhosted.org/packages/81/79/92393c02ff640059ca6e883216690abc4933abef065b7689e7254fbb97ce/psycopg2_binary-2.9.6-cp310-cp310-win32.whl", hash = "sha256:b6c8288bb8a84b47e07013bb4850f50538aa913d487579e1921724631d02ea1b"},
-    {url = "https://files.pythonhosted.org/packages/87/65/d7c77f8d8bca9d5e601366f34028e2d5702f53cdb48fcda05a5f6f14cdee/psycopg2_binary-2.9.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c48d8f2db17f27d41fb0e2ecd703ea41984ee19362cbce52c097963b3a1b4365"},
-    {url = "https://files.pythonhosted.org/packages/8c/71/a799f1b4e2cc3e3c3fce15b8dc3a545a48b4298f5f3066e0c2da3914eeb7/psycopg2_binary-2.9.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4d67fbdaf177da06374473ef6f7ed8cc0a9dc640b01abfe9e8a2ccb1b1402c1f"},
-    {url = "https://files.pythonhosted.org/packages/8d/2f/1bc5e64043c4666a395f9b777c8c10bced656dd25e55a539cbf166e418da/psycopg2_binary-2.9.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:2ab652e729ff4ad76d400df2624d223d6e265ef81bb8aa17fbd63607878ecbee"},
-    {url = "https://files.pythonhosted.org/packages/8e/b7/5ba29036d3cacdf707bb19bc80fbad6b90ce3ef8b13f51dfc2aa1fd92feb/psycopg2_binary-2.9.6-cp39-cp39-win_amd64.whl", hash = "sha256:f6a88f384335bb27812293fdb11ac6aee2ca3f51d3c7820fe03de0a304ab6249"},
-    {url = "https://files.pythonhosted.org/packages/98/3e/05ab0922422c91ca0ecb5939a100f8dc2b5d15f5978433beadc87c5329bf/psycopg2-binary-2.9.6.tar.gz", hash = "sha256:1f64dcfb8f6e0c014c7f55e51c9759f024f70ea572fbdef123f85318c297947c"},
-    {url = "https://files.pythonhosted.org/packages/99/19/032fbdae2f81275d8b3ab95f0f8b3f93f0bb7efe164bc50b7240f3a18d85/psycopg2_binary-2.9.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c7e62ab8b332147a7593a385d4f368874d5fe4ad4e341770d4983442d89603e3"},
-    {url = "https://files.pythonhosted.org/packages/a8/03/14e2c358d25e032b00b074a1267c3722a275e7300939d00378fa3f451d17/psycopg2_binary-2.9.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:34b9ccdf210cbbb1303c7c4db2905fa0319391bd5904d32689e6dd5c963d2ea8"},
-    {url = "https://files.pythonhosted.org/packages/ab/a6/8caa3c6c1a0623d13fdc25c052ea792dac887684b0c13a082d08485970f3/psycopg2_binary-2.9.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:02c0f3757a4300cf379eb49f543fb7ac527fb00144d39246ee40e1df684ab514"},
-    {url = "https://files.pythonhosted.org/packages/ac/2b/e772581482eab43fd47ef1d67a657816e1c5bf97aa66b80ed59366c3fec7/psycopg2_binary-2.9.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15e2ee79e7cf29582ef770de7dab3d286431b01c3bb598f8e05e09601b890081"},
-    {url = "https://files.pythonhosted.org/packages/ae/ab/31bacfb21076c8527889c7716ed5593826dc3e4ab2dbf39da283baaa7fd1/psycopg2_binary-2.9.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6460c7a99fc939b849431f1e73e013d54aa54293f30f1109019c56a0b2b2ec2f"},
-    {url = "https://files.pythonhosted.org/packages/ae/d9/4bf3be330a0bf0ea3dc0d0742188d095df35abfc5e31565f86f2ed2aa37c/psycopg2_binary-2.9.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d26e0342183c762de3276cca7a530d574d4e25121ca7d6e4a98e4f05cb8e4df7"},
-    {url = "https://files.pythonhosted.org/packages/b0/90/f65b852b3061234c044db917071c3b65d653e5e81bc1b5b579a21489e0b7/psycopg2_binary-2.9.6-cp38-cp38-win32.whl", hash = "sha256:4dfb4be774c4436a4526d0c554af0cc2e02082c38303852a36f6456ece7b3503"},
-    {url = "https://files.pythonhosted.org/packages/b3/92/3298786e64742a6d8c5d849cd38168fbfb88a8716fd1b2802a8d1f91dcb2/psycopg2_binary-2.9.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e9182eb20f41417ea1dd8e8f7888c4d7c6e805f8a7c98c1081778a3da2bee3e4"},
-    {url = "https://files.pythonhosted.org/packages/b7/42/8529d43c6c3a562d8f83a56cce83dbfbd898e05a90ae9517fb40f9670317/psycopg2_binary-2.9.6-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8122cfc7cae0da9a3077216528b8bb3629c43b25053284cc868744bfe71eb141"},
-    {url = "https://files.pythonhosted.org/packages/b7/b5/fc67e6fc3bcc1a32233d85b9939a544effa2cd8a305cee6991fd9697b218/psycopg2_binary-2.9.6-cp37-cp37m-win32.whl", hash = "sha256:a8c28fd40a4226b4a84bdf2d2b5b37d2c7bd49486b5adcc200e8c7ec991dfa7e"},
-    {url = "https://files.pythonhosted.org/packages/b8/a0/43731a30402ed39723029b78b22f739980d8a4246a9b07ac27495e664181/psycopg2_binary-2.9.6-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3ed340d2b858d6e6fb5083f87c09996506af483227735de6964a6100b4e6a54"},
-    {url = "https://files.pythonhosted.org/packages/bc/19/64dbb3f803dae8ec6f23e833635de99db51d5d573add03c8b9b3a2dbd6d5/psycopg2_binary-2.9.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e99e34c82309dd78959ba3c1590975b5d3c862d6f279f843d47d26ff89d7d7e1"},
-    {url = "https://files.pythonhosted.org/packages/bd/df/841fadc536c1d4dd95bb26998851e9a68a2693bf5e71082858c37d01508c/psycopg2_binary-2.9.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7e13a5a2c01151f1208d5207e42f33ba86d561b7a89fca67c700b9486a06d0e2"},
-    {url = "https://files.pythonhosted.org/packages/bf/cb/e8b1f1e402f11119f9031178f23e1eefc10321c81355deee644d206eeb15/psycopg2_binary-2.9.6-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:c83a74b68270028dc8ee74d38ecfaf9c90eed23c8959fca95bd703d25b82c88e"},
-    {url = "https://files.pythonhosted.org/packages/ca/12/c7c6e20972743081831c54470a326de797164673d02d6443251138a072ff/psycopg2_binary-2.9.6-cp38-cp38-win_amd64.whl", hash = "sha256:02c6e3cf3439e213e4ee930308dc122d6fb4d4bea9aef4a12535fbd605d1a2fe"},
-    {url = "https://files.pythonhosted.org/packages/ce/36/bc8eccfb702596ec1f8b696c8aa9f1533b82e044cb87b460ad4691ca666b/psycopg2_binary-2.9.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e78e6e2a00c223e164c417628572a90093c031ed724492c763721c2e0bc2a8df"},
-    {url = "https://files.pythonhosted.org/packages/cf/30/816c79e0a324d2e1e598f912b566058320753eac4796dc5c39024013c9b0/psycopg2_binary-2.9.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:65bee1e49fa6f9cf327ce0e01c4c10f39165ee76d35c846ade7cb0ec6683e303"},
-    {url = "https://files.pythonhosted.org/packages/db/a1/3de02c36b5fdc7031b32b26779cba70d8f267db9f524824f577266c9d76b/psycopg2_binary-2.9.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afe64e9b8ea66866a771996f6ff14447e8082ea26e675a295ad3bdbffdd72afb"},
-    {url = "https://files.pythonhosted.org/packages/dd/ff/5c240396258876f2757f2713c66ba0e213fb8dab7b567f5bd9d356fd79ce/psycopg2_binary-2.9.6-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:cfec476887aa231b8548ece2e06d28edc87c1397ebd83922299af2e051cf2827"},
-    {url = "https://files.pythonhosted.org/packages/e0/07/3c39e282a6fdfc330b95de3c2a44d1584df6d5604e2e0b69b732fd643f60/psycopg2_binary-2.9.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f81e65376e52f03422e1fb475c9514185669943798ed019ac50410fb4c4df232"},
-    {url = "https://files.pythonhosted.org/packages/e1/79/787079c90f0aa236d1e944f4486d82bda1a576bd2d9134bb4fd05c62058e/psycopg2_binary-2.9.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9972aad21f965599ed0106f65334230ce826e5ae69fda7cbd688d24fa922415e"},
-    {url = "https://files.pythonhosted.org/packages/e7/a5/8c99d01debda922e5402c88c93bfbd0c860fb94adf2a5397cac1e4082b98/psycopg2_binary-2.9.6-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a76e027f87753f9bd1ab5f7c9cb8c7628d1077ef927f5e2446477153a602f2c"},
-    {url = "https://files.pythonhosted.org/packages/e8/7b/b33287978ddc87ecbee713f361d54c40428d5cfa62935442bc737a847f86/psycopg2_binary-2.9.6-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d57c3fd55d9058645d26ae37d76e61156a27722097229d32a9e73ed54819982a"},
-    {url = "https://files.pythonhosted.org/packages/e9/e9/cc2820de0d2748937b3dcf9bd66d3277ebb9d6d8502621d946ddd0f6cf14/psycopg2_binary-2.9.6-cp310-cp310-win_amd64.whl", hash = "sha256:61b047a0537bbc3afae10f134dc6393823882eb263088c271331602b672e52e9"},
-    {url = "https://files.pythonhosted.org/packages/eb/3a/6bbc247a380250b898540acc9ddfce083667f4390ce4b68a26f4a0b60ef7/psycopg2_binary-2.9.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4ea29fc3ad9d91162c52b578f211ff1c931d8a38e1f58e684c45aa470adf19e2"},
-    {url = "https://files.pythonhosted.org/packages/f2/5e/7a5fe435e603942c384342d67247e31f8ac6b3e57b396dcb137da0e88002/psycopg2_binary-2.9.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:441cc2f8869a4f0f4bb408475e5ae0ee1f3b55b33f350406150277f7f35384fc"},
-    {url = "https://files.pythonhosted.org/packages/fa/7c/d0c364f994dbc37245a67f33999704c286ed45a737b88dff24c252a942c5/psycopg2_binary-2.9.6-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:cacbdc5839bdff804dfebc058fe25684cae322987f7a38b0168bc1b2df703fb1"},
+"psycopg2-binary 2.9.7" = [
+    {url = "https://files.pythonhosted.org/packages/01/40/660b4fae9d3c6f8281bc514f13c2915cbadfb1903ac57d0d67a3b599637c/psycopg2_binary-2.9.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ea5f8ee87f1eddc818fc04649d952c526db4426d26bab16efbe5a0c52b27d6ab"},
+    {url = "https://files.pythonhosted.org/packages/01/a3/50875e4480556726ad7f9092ae5bccdc47fad92425373cbec1f6b302a0e4/psycopg2_binary-2.9.7-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc10da7e7df3380426521e8c1ed975d22df678639da2ed0ec3244c3dc2ab54c8"},
+    {url = "https://files.pythonhosted.org/packages/04/dd/60643c99ab7c364c8693d3c238f8144443d0bfbba415a0720bd717853b24/psycopg2_binary-2.9.7-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6d92e139ca388ccfe8c04aacc163756e55ba4c623c6ba13d5d1595ed97523e4b"},
+    {url = "https://files.pythonhosted.org/packages/0a/76/b6e393287b6dbf241a332fca869f8f6c675b97bf42429266675988de2e8c/psycopg2_binary-2.9.7-cp310-cp310-win32.whl", hash = "sha256:122641b7fab18ef76b18860dd0c772290566b6fb30cc08e923ad73d17461dc63"},
+    {url = "https://files.pythonhosted.org/packages/0b/8d/178a18ee8f54aad06b299d4dbb51a82698f89a1861a7627e5cd46bb6a658/psycopg2_binary-2.9.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac83ab05e25354dad798401babaa6daa9577462136ba215694865394840e31f8"},
+    {url = "https://files.pythonhosted.org/packages/0e/1d/328ded51096872751727628c54f05953d3288672888178358ef4bdf085b0/psycopg2_binary-2.9.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:95a7a747bdc3b010bb6a980f053233e7610276d55f3ca506afff4ad7749ab58a"},
+    {url = "https://files.pythonhosted.org/packages/1d/87/3b0d28ce44a0173ca6aa7e0ab073e24a80040fb04dd3d883fa2184ae402d/psycopg2_binary-2.9.7-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:4eec5d36dbcfc076caab61a2114c12094c0b7027d57e9e4387b634e8ab36fd44"},
+    {url = "https://files.pythonhosted.org/packages/20/81/4940235d18747f865d47eb38b98f38acc24b39278b12e20a0fdd20e0a132/psycopg2_binary-2.9.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f309b77a7c716e6ed9891b9b42953c3ff7d533dc548c1e33fddc73d2f5e21f9"},
+    {url = "https://files.pythonhosted.org/packages/22/c8/0b527292da92cb828b4e2fad2e50867c85855e6700529e4149f89e51e066/psycopg2_binary-2.9.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ad26d4eeaa0d722b25814cce97335ecf1b707630258f14ac4d2ed3d1d8415265"},
+    {url = "https://files.pythonhosted.org/packages/28/82/e741d41861ec7982899070d2686f7d5181d95079c23478baf5322f81111d/psycopg2_binary-2.9.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2b04da24cbde33292ad34a40db9832a80ad12de26486ffeda883413c9e1b1d5e"},
+    {url = "https://files.pythonhosted.org/packages/35/23/3f1c2a660b499b2f618cd716d24e09d7311d3633d48910ef8662e15640c6/psycopg2_binary-2.9.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c721ee464e45ecf609ff8c0a555018764974114f671815a0a7152aedb9f3343"},
+    {url = "https://files.pythonhosted.org/packages/37/d8/6d94513d2bc993cdbf309017425b2b691da2b0e26b446d17866c57f99d8c/psycopg2_binary-2.9.7-cp311-cp311-win_amd64.whl", hash = "sha256:8a136c8aaf6615653450817a7abe0fc01e4ea720ae41dfb2823eccae4b9062a3"},
+    {url = "https://files.pythonhosted.org/packages/37/e6/7dd26ba148a02b7e78471ed7ce177e9890167994c5a1d4182361b9bee4cc/psycopg2_binary-2.9.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4ecc15666f16f97709106d87284c136cdc82647e1c3f8392a672616aed3c7151"},
+    {url = "https://files.pythonhosted.org/packages/3c/df/73e464f6b86ff9dbb3bfdbed705248940193f056a0b1821765c261a3d4bf/psycopg2_binary-2.9.7-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad5ec10b53cbb57e9a2e77b67e4e4368df56b54d6b00cc86398578f1c635f329"},
+    {url = "https://files.pythonhosted.org/packages/3d/0d/16234b22993a48c500978b5ab1e6d85e68b8680119991f2a113157847f3c/psycopg2_binary-2.9.7-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c82986635a16fb1fa15cd5436035c88bc65c3d5ced1cfaac7f357ee9e9deddd4"},
+    {url = "https://files.pythonhosted.org/packages/40/c9/64b58cca12ad02d59fd90edce00e6b0a215abe897e6884a0e1a624a0bd61/psycopg2_binary-2.9.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26484e913d472ecb6b45937ea55ce29c57c662066d222fb0fbdc1fab457f18c5"},
+    {url = "https://files.pythonhosted.org/packages/41/63/74412365a565c0da42ec3733bd9d3bc736017853f84a2e000796429b7373/psycopg2_binary-2.9.7-cp37-cp37m-win32.whl", hash = "sha256:81d5dd2dd9ab78d31a451e357315f201d976c131ca7d43870a0e8063b6b7a1ec"},
+    {url = "https://files.pythonhosted.org/packages/45/f4/4da1e7f836de4fa3ddb294bb1d4c08daa5cd7b261a6b9a5b50a653a1a29f/psycopg2-binary-2.9.7.tar.gz", hash = "sha256:1b918f64a51ffe19cd2e230b3240ba481330ce1d4b7875ae67305bd1d37b041c"},
+    {url = "https://files.pythonhosted.org/packages/45/ff/5a2e9608efe865da075205833a1aa301144d8578667cdd5206ece876601c/psycopg2_binary-2.9.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3fbb1184c7e9d28d67671992970718c05af5f77fc88e26fd7136613c4ece1f89"},
+    {url = "https://files.pythonhosted.org/packages/46/b5/32f738ebcba965b2b38b794eb3e165560161bdc57f9738fca4ce86f5bf8a/psycopg2_binary-2.9.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2df562bb2e4e00ee064779902d721223cfa9f8f58e7e52318c97d139cf7f012d"},
+    {url = "https://files.pythonhosted.org/packages/4e/33/5675444ad06ee3bf6aa6340a1a6b48ecaa7cc9fdd16c94305aa34e000f66/psycopg2_binary-2.9.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9dcfd5d37e027ec393a303cc0a216be564b96c80ba532f3d1e0d2b5e5e4b1e6e"},
+    {url = "https://files.pythonhosted.org/packages/50/18/08a234a7625ee8c3363258ba711d72aa39f966bb12ffe7412748239dedca/psycopg2_binary-2.9.7-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee919b676da28f78f91b464fb3e12238bd7474483352a59c8a16c39dfc59f0c5"},
+    {url = "https://files.pythonhosted.org/packages/5a/91/c070590608ed1664e78dae6064cf6ea39d0d4368b26641da5b0bb4a349c9/psycopg2_binary-2.9.7-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4f37bbc6588d402980ffbd1f3338c871368fb4b1cfa091debe13c68bb3852b3"},
+    {url = "https://files.pythonhosted.org/packages/60/65/46a18c1a0c7532c38cfb610a5550adc565eafab0f2d9168c90908eb328a4/psycopg2_binary-2.9.7-cp38-cp38-win_amd64.whl", hash = "sha256:d0b16e5bb0ab78583f0ed7ab16378a0f8a89a27256bb5560402749dbe8a164d7"},
+    {url = "https://files.pythonhosted.org/packages/67/8f/c535b5f62c00671171b50d565f6332df7347c36d4340ba0334a9a0f9006c/psycopg2_binary-2.9.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:42a62ef0e5abb55bf6ffb050eb2b0fcd767261fa3faf943a4267539168807522"},
+    {url = "https://files.pythonhosted.org/packages/6f/ac/0cc0412f1710598537af8021a7c63334daaa8d3474d17133a6805bf54f5b/psycopg2_binary-2.9.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00d8db270afb76f48a499f7bb8fa70297e66da67288471ca873db88382850bf4"},
+    {url = "https://files.pythonhosted.org/packages/70/47/4b9a42551ae3f38bc6764db9c2735453919390b98c39f8818f03f766fa52/psycopg2_binary-2.9.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6822c9c63308d650db201ba22fe6648bd6786ca6d14fdaf273b17e15608d0852"},
+    {url = "https://files.pythonhosted.org/packages/75/2e/772b1f1a74a1c6f65601123aa6508b4292792b85aed4c4fdf502908c1b41/psycopg2_binary-2.9.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:59f7e9109a59dfa31efa022e94a244736ae401526682de504e87bd11ce870c22"},
+    {url = "https://files.pythonhosted.org/packages/76/b5/2708dfff3b20e2857000b7ac7f93fb17e98e266c36cd027e25b423a59aa4/psycopg2_binary-2.9.7-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9b0c2b466b2f4d89ccc33784c4ebb1627989bd84a39b79092e560e937a11d4ac"},
+    {url = "https://files.pythonhosted.org/packages/7a/da/3bd2e6ce4d6644d791b6f7eddd31da002c02956e2d410a25a62ed380dec5/psycopg2_binary-2.9.7-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1c31c2606ac500dbd26381145684d87730a2fac9a62ebcfbaa2b119f8d6c19f4"},
+    {url = "https://files.pythonhosted.org/packages/7c/9e/89462a3a42a4f2bd92a098717966e469c7aec96ec4cc1b1be33161062244/psycopg2_binary-2.9.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e02bc4f2966475a7393bd0f098e1165d470d3fa816264054359ed4f10f6914ea"},
+    {url = "https://files.pythonhosted.org/packages/7c/e4/66aab8713cd4223068de41405a82a855eedcf77848ca4b6e6a8e6ec5c189/psycopg2_binary-2.9.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f02f4a72cc3ab2565c6d9720f0343cb840fb2dc01a2e9ecb8bc58ccf95dc5c06"},
+    {url = "https://files.pythonhosted.org/packages/84/a3/fe91300fc3753bbb1b3e90bbcf6a72023c5891898dc31e899f61459f701d/psycopg2_binary-2.9.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f94cb12150d57ea433e3e02aabd072205648e86f1d5a0a692d60242f7809b15"},
+    {url = "https://files.pythonhosted.org/packages/87/11/d278651017d2e6971474836f122d589d15a55a1c71bdce3c5317a450db17/psycopg2_binary-2.9.7-cp38-cp38-win32.whl", hash = "sha256:fdca0511458d26cf39b827a663d7d87db6f32b93efc22442a742035728603d5f"},
+    {url = "https://files.pythonhosted.org/packages/89/1c/58dc2bc679e55f1d9d38e70c64cfac8cf76aa60d0eba49693e1a074721f0/psycopg2_binary-2.9.7-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:11abdbfc6f7f7dea4a524b5f4117369b0d757725798f1593796be6ece20266cb"},
+    {url = "https://files.pythonhosted.org/packages/8b/fa/cec4ab1f4c64ee7e311de9f582982904bdb0ab9ee93e03fbe1b748e334c4/psycopg2_binary-2.9.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a7968fd20bd550431837656872c19575b687f3f6f98120046228e451e4064df"},
+    {url = "https://files.pythonhosted.org/packages/95/e6/b7ae7227460f52b936aeca2c6e2d0ecbe5938ba6ca7976cbff3f5c6a0648/psycopg2_binary-2.9.7-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:ced63c054bdaf0298f62681d5dcae3afe60cbae332390bfb1acf0e23dcd25fc8"},
+    {url = "https://files.pythonhosted.org/packages/9b/ae/dd11e38562224721f4928147ce70fa17f2c28fc562a22a40cc0db1026297/psycopg2_binary-2.9.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1011eeb0c51e5b9ea1016f0f45fa23aca63966a4c0afcf0340ccabe85a9f65bd"},
+    {url = "https://files.pythonhosted.org/packages/a0/81/6e4e15dbbc5eb1fa12ff79f5a25a72e2115d85d63ff9f17d56ebb1545554/psycopg2_binary-2.9.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:642df77484b2dcaf87d4237792246d8068653f9e0f5c025e2c692fc56b0dda70"},
+    {url = "https://files.pythonhosted.org/packages/a1/7c/06f7897b1740556f2379bc96134b53fc24115ac66ccffe3136f53cb505d4/psycopg2_binary-2.9.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4fe13712357d802080cfccbf8c6266a3121dc0e27e2144819029095ccf708372"},
+    {url = "https://files.pythonhosted.org/packages/a3/0e/18d7476bc94a26e5adefbdf0cbeec67a15fdfa8d983baacc25d91e1a3330/psycopg2_binary-2.9.7-cp310-cp310-win_amd64.whl", hash = "sha256:f8651cf1f144f9ee0fa7d1a1df61a9184ab72962531ca99f077bbdcba3947c58"},
+    {url = "https://files.pythonhosted.org/packages/a5/f6/e31d985a76785e61f0c3d59e1fadf3e0e5d9ddb62d0ee00daac8aa8b0640/psycopg2_binary-2.9.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbbc3c5d15ed76b0d9db7753c0db40899136ecfe97d50cbde918f630c5eb857a"},
+    {url = "https://files.pythonhosted.org/packages/ab/6d/20dcb9fa3f0c4d8fbada034cf3e12abf30f196d7c9cd95d2d3ea05346cfd/psycopg2_binary-2.9.7-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb1c0e682138f9067a58fc3c9a9bf1c83d8e08cfbee380d858e63196466d5c86"},
+    {url = "https://files.pythonhosted.org/packages/b0/12/1c86cfad8cb6205645848cf0dabcfa563aa444bb0c2ad18758b97bd03611/psycopg2_binary-2.9.7-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e5666632ba2b0d9757b38fc17337d84bdf932d38563c5234f5f8c54fd01349c9"},
+    {url = "https://files.pythonhosted.org/packages/b2/ef/3349ef49f40373a74bdd642d1aff940ef17ff8fb75a25cebb61a344206fc/psycopg2_binary-2.9.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5ee89587696d808c9a00876065d725d4ae606f5f7853b961cdbc348b0f7c9a1"},
+    {url = "https://files.pythonhosted.org/packages/b6/8d/26a8bdebc88fb82cc80bc5541990f17b2b53bf7b61199543941dd16fe115/psycopg2_binary-2.9.7-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:692df8763b71d42eb8343f54091368f6f6c9cfc56dc391858cdb3c3ef1e3e584"},
+    {url = "https://files.pythonhosted.org/packages/bd/bd/69c7afabcf299462740d41883719413662e536334bd9bed4a6e9f3138bcd/psycopg2_binary-2.9.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:024eaeb2a08c9a65cd5f94b31ace1ee3bb3f978cd4d079406aef85169ba01f08"},
+    {url = "https://files.pythonhosted.org/packages/bd/dd/85be0d048ff1e4e4b75184fdc042503f03cf07c6cb4c0d9aee5acf616f68/psycopg2_binary-2.9.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7db7b9b701974c96a88997d458b38ccb110eba8f805d4b4f74944aac48639b42"},
+    {url = "https://files.pythonhosted.org/packages/c0/75/cf5dd290e8f910e6e566077f3f91ee4bb7622d2adf9d4187d4814249e779/psycopg2_binary-2.9.7-cp311-cp311-win32.whl", hash = "sha256:ded8e15f7550db9e75c60b3d9fcbc7737fea258a0f10032cdb7edc26c2a671fd"},
+    {url = "https://files.pythonhosted.org/packages/c1/05/5119f732b2d10b0edee9a1cb687e7c83f8023a1e8092ecfa60c8f3f2805e/psycopg2_binary-2.9.7-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f955aa50d7d5220fcb6e38f69ea126eafecd812d96aeed5d5f3597f33fad43bb"},
+    {url = "https://files.pythonhosted.org/packages/cd/b4/a7c1b328ef612d30520e44259fa772e2a3bd6f4c2c8694af96382dd90cce/psycopg2_binary-2.9.7-cp37-cp37m-win_amd64.whl", hash = "sha256:62cb6de84d7767164a87ca97e22e5e0a134856ebcb08f21b621c6125baf61f16"},
+    {url = "https://files.pythonhosted.org/packages/d5/53/2a16faec262b204636d35e36857ca0ad1311e0b608c9363f3f70271c8d53/psycopg2_binary-2.9.7-cp39-cp39-win_amd64.whl", hash = "sha256:eb3b8d55924a6058a26db69fb1d3e7e32695ff8b491835ba9f479537e14dcf9f"},
+    {url = "https://files.pythonhosted.org/packages/d7/8c/0fd5fdd6896ed709d464583e613d353ac16223407ebc4ec77478e27d6ca4/psycopg2_binary-2.9.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:51d1b42d44f4ffb93188f9b39e6d1c82aa758fdb8d9de65e1ddfe7a7d250d7ad"},
+    {url = "https://files.pythonhosted.org/packages/e3/b2/f578b59b83563648c7224bae9397dc4bab6fe2dd2b4338786bb7e373bc4a/psycopg2_binary-2.9.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17cc17a70dfb295a240db7f65b6d8153c3d81efb145d76da1e4a096e9c5c0e63"},
+    {url = "https://files.pythonhosted.org/packages/eb/47/eae7132e971dfff03682b7d692143f42186ed7727117ecb7ec324d856239/psycopg2_binary-2.9.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2993ccb2b7e80844d534e55e0f12534c2871952f78e0da33c35e648bf002bbff"},
+    {url = "https://files.pythonhosted.org/packages/ec/44/2d38eb38d7626a226c8b6fc018410d36182786a2f1df9c7973a35eb4fbbd/psycopg2_binary-2.9.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2dec5a75a3a5d42b120e88e6ed3e3b37b46459202bb8e36cd67591b6e5feebc1"},
+    {url = "https://files.pythonhosted.org/packages/ef/e5/ac96e3b684ee398ade411b052e4ad94f3ff9a492b7b0a1349cd017ef7741/psycopg2_binary-2.9.7-cp39-cp39-win32.whl", hash = "sha256:18f12632ab516c47c1ac4841a78fddea6508a8284c7cf0f292cb1a523f2e2379"},
+    {url = "https://files.pythonhosted.org/packages/f0/dc/c233f066e6c34b2b6a226f95a5dc55058128a234bc9852952d30c1ef2f23/psycopg2_binary-2.9.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6a8b575ac45af1eaccbbcdcf710ab984fd50af048fe130672377f78aaff6fc1"},
+    {url = "https://files.pythonhosted.org/packages/f7/e3/aa8c13acb31e64e99cad3d9401631bd03abb12be5a6c1a8472de60f240ae/psycopg2_binary-2.9.7-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:7952807f95c8eba6a8ccb14e00bf170bb700cafcec3924d565235dffc7dc4ae8"},
+    {url = "https://files.pythonhosted.org/packages/fe/f6/ff2218e4188ca444416dfbe215b25248ee21695a92d49df4caa37ad5d054/psycopg2_binary-2.9.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:094af2e77a1976efd4956a031028774b827029729725e136514aae3cdf49b87b"},
 ]
 "py-cpuinfo 9.0.0" = [
     {url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
@@ -1431,17 +1442,17 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/49/6f/07dab31ca496feda35cf3455b9e9380c43b5c685bb54ad890831c790da38/pygaljs-1.0.2-py2.py3-none-any.whl", hash = "sha256:d75e18cb21cc2cda40c45c3ee690771e5e3d4652bf57206f20137cf475c0dbe8"},
     {url = "https://files.pythonhosted.org/packages/75/19/3a53f34232a9e6ddad665e71c83693c5db9a31f71785105905c5bc9fbbba/pygaljs-1.0.2.tar.gz", hash = "sha256:0b71ee32495dcba5fbb4a0476ddbba07658ad65f5675e4ad409baf154dec5111"},
 ]
-"pygments 2.15.1" = [
-    {url = "https://files.pythonhosted.org/packages/34/a7/37c8d68532ba71549db4212cb036dbd6161b40e463aba336770e80c72f84/Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {url = "https://files.pythonhosted.org/packages/89/6b/2114e54b290824197006e41be3f9bbe1a26e9c39d1f5fa20a6d62945a0b3/Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+"pygments 2.16.1" = [
+    {url = "https://files.pythonhosted.org/packages/43/88/29adf0b44ba6ac85045e63734ae0997d3c58d8b1a91c914d240828d0d73d/Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {url = "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
-"pytest 7.4.0" = [
-    {url = "https://files.pythonhosted.org/packages/33/b2/741130cbcf2bbfa852ed95a60dc311c9e232c7ed25bac3d9b8880a8df4ae/pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
-    {url = "https://files.pythonhosted.org/packages/a7/f3/dadfbdbf6b6c8b5bd02adb1e08bc9fbb45ba51c68b0893fa536378cdf485/pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+"pytest 7.4.1" = [
+    {url = "https://files.pythonhosted.org/packages/5b/a2/4db5b065b0694b330f2b3c47e64abda0a470839da5119a404610d6349a11/pytest-7.4.1.tar.gz", hash = "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab"},
+    {url = "https://files.pythonhosted.org/packages/78/af/1a79db43409ea8569a8a91d0a87db4445c7de4cefcf6141e9a5c77dda2d6/pytest-7.4.1-py3-none-any.whl", hash = "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"},
 ]
-"pytest-asyncio 0.21.0" = [
-    {url = "https://files.pythonhosted.org/packages/66/73/817ddb37c627338ecbb96486c03fe69a19bef72de1b6bd641aa06fed13f4/pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c"},
-    {url = "https://files.pythonhosted.org/packages/85/c7/9db0c6215f12f26b590c24acc96d048e03989315f198454540dff95109cd/pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b"},
+"pytest-asyncio 0.21.1" = [
+    {url = "https://files.pythonhosted.org/packages/5a/85/d39ef5f69d5597a206f213ce387bcdfa47922423875829f7a98a87d33281/pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {url = "https://files.pythonhosted.org/packages/7d/2c/2e5ab8708667972ee31b88bb6fed680ed5ba92dfc2db28e07d0d68d8b3b1/pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
 ]
 "pytest-benchmark 4.0.0" = [
     {url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
@@ -1462,6 +1473,10 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
 "requests 2.31.0" = [
     {url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
     {url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+"sentry-sdk 1.30.0" = [
+    {url = "https://files.pythonhosted.org/packages/17/22/dbd5f854f373214d48585eeb6844e50a8dd1600f435d9033493f76f66dfa/sentry_sdk-1.30.0-py2.py3-none-any.whl", hash = "sha256:2e53ad63f96bb9da6570ba2e755c267e529edcf58580a2c0d2a11ef26e1e678b"},
+    {url = "https://files.pythonhosted.org/packages/f1/2e/687447460d119eac1c7a784053b7ff9f66760c2be22abb0b724a43ea6160/sentry-sdk-1.30.0.tar.gz", hash = "sha256:7dc873b87e1faf4d00614afd1058bfa1522942f33daef8a59f90de8ed75cd10c"},
 ]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1594,9 +1609,9 @@ content_hash = "sha256:dd45ba42bc8e144af1da6581838928a067ae39229dacc87eeb573f98c
     {url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
     {url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
 ]
-"urllib3 2.0.3" = [
-    {url = "https://files.pythonhosted.org/packages/8a/03/ad9306a50d05c166e3456fe810f33cee2b8b2a7a6818ec5d4908c4ec6b36/urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {url = "https://files.pythonhosted.org/packages/d6/af/3b4cfedd46b3addab52e84a71ab26518272c23c77116de3c61ead54af903/urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+"urllib3 2.0.4" = [
+    {url = "https://files.pythonhosted.org/packages/31/ab/46bec149bbd71a4467a3063ac22f4486ecd2ceb70ae8c70d5d8e4c2a7946/urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
+    {url = "https://files.pythonhosted.org/packages/9b/81/62fd61001fa4b9d0df6e31d47ff49cfa9de4af03adecf339c7bc30656b37/urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
 ]
 "werkzeug 2.2.3" = [
     {url = "https://files.pythonhosted.org/packages/02/3c/baaebf3235c87d61d6593467056d5a8fba7c75ac838b8d100a5e64eba7a0/Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "protobuf<4.0.0",  # for protobuf support
     "aiopg",  # for async postgresql support
     "prometheus-client",  # for prometheus metrics
+    "sentry-sdk",  # for sentry tracing
     "typing-extensions",
     "mypy",
     "black",
@@ -240,6 +241,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "prometheus_client.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "sentry_sdk.*"
 ignore_missing_imports = true
 
 [tool.black]

--- a/tests/benchmarks/test_endpoint.py
+++ b/tests/benchmarks/test_endpoint.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hiku.extensions import QueryParserCache
+from hiku.extensions.query_parse_cache import QueryParserCache
 from hiku.extensions.query_transform_cache import QueryTransformCache
 from hiku.extensions.query_validation_cache import QueryValidationCache
 from hiku.graph import Graph, Link, Node, Root, Field

--- a/tests/extensions/test_custom_context.py
+++ b/tests/extensions/test_custom_context.py
@@ -1,0 +1,33 @@
+import pytest
+
+from hiku.extensions.context import CustomContext
+from hiku.types import String
+from hiku.executors.sync import SyncExecutor
+from hiku.engine import Engine, pass_context
+from hiku.endpoint.graphql import GraphQLEndpoint
+from hiku.graph import Field, Root, Graph
+
+
+@pytest.fixture(name="sync_graph")
+def sync_graph_fixture():
+    def question(fields):
+        return ["Number?" for _ in fields]
+
+    @pass_context
+    def answer(ctx, fields):
+        return [ctx['answer'] for _ in fields]
+
+    return Graph([Root([
+        Field("question", String, question),
+        Field("answer", String, answer),
+    ])])
+
+
+def test_custom_context_extension(sync_graph):
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[CustomContext(lambda _: {"answer": "42"})],
+    )
+
+    result = endpoint.dispatch({"query": "{answer}"}, {'a': 'b'})
+    assert result == {"data": {"answer": "42"}}

--- a/tests/extensions/test_query_depth_validator.py
+++ b/tests/extensions/test_query_depth_validator.py
@@ -1,0 +1,55 @@
+import pytest
+
+from hiku.extensions.query_depth_validator import QueryDepthValidator
+from hiku.types import Sequence, String, TypeRef
+from hiku.executors.sync import SyncExecutor
+from hiku.engine import Engine
+from hiku.endpoint.graphql import GraphQLEndpoint
+from hiku.graph import Field, Link, Node, Root, Graph
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+@pytest.fixture(name="sync_graph")
+def sync_graph_fixture():
+    return Graph([
+        Node('User', [
+            Field('id', String, noop),
+            Field('name', String, noop),
+            Link('friends', Sequence[TypeRef['User']], noop, requires='id'),
+        ]),
+        Root([
+            Link("user", TypeRef['User'], noop, requires=None),
+        ])
+    ])
+
+
+def test_query_depth_validator(sync_graph):
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[
+            QueryDepthValidator(max_depth=2),
+        ],
+    )
+
+    query = """
+    query {
+        user {
+            id
+            name
+            friends {
+                id
+                name
+                friends {
+                    id
+                    name
+                }
+            }
+        }
+    }
+    """
+
+    result = endpoint.dispatch({"query": query})
+    assert result == {"errors": [{"message": "Query depth 4 exceeds maximum allowed depth 2"}]}

--- a/tests/extensions/test_query_parser_cache.py
+++ b/tests/extensions/test_query_parser_cache.py
@@ -9,7 +9,7 @@ from hiku.executors.sync import SyncExecutor
 from hiku.engine import Engine
 from hiku.endpoint.graphql import GraphQLEndpoint
 from hiku.graph import Field, Root, Graph
-from hiku.extensions import QueryParserCache
+from hiku.extensions.query_parse_cache import QueryParserCache
 
 
 @pytest.fixture(name="sync_graph")

--- a/tests/extensions/test_query_parser_cache.py
+++ b/tests/extensions/test_query_parser_cache.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import pytest
+
+from graphql import parse
+
+from hiku.types import String
+from hiku.executors.sync import SyncExecutor
+from hiku.engine import Engine
+from hiku.endpoint.graphql import GraphQLEndpoint
+from hiku.graph import Field, Root, Graph
+from hiku.extensions import QueryParserCache
+
+
+@pytest.fixture(name="sync_graph")
+def sync_graph_fixture():
+    def question(fields):
+        return ["Number?" for _ in fields]
+
+    def answer(fields):
+        return ["42" for _ in fields]
+
+    return Graph([Root([
+        Field("question", String, question),
+        Field("answer", String, answer),
+    ])])
+
+
+def test_query_parser_cache_extension(sync_graph):
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[QueryParserCache(2)],
+    )
+
+    with patch("hiku.readers.graphql.parse", wraps=parse) as mock_parse:
+        result = endpoint.dispatch({"query": "{answer}"})
+        assert result == {"data": {"answer": "42"}}
+
+        assert mock_parse.call_count == 1
+
+        for _ in range(3):
+            result = endpoint.dispatch({"query": "{answer}"})
+            assert result == {"data": {"answer": "42"}}
+
+        # check that parse was called only once
+        assert mock_parse.call_count == 1
+
+        # check that new query was parsed
+        result = endpoint.dispatch({"query": "{question}"})
+        assert result == {"data": {"question": "Number?"}}
+
+        assert mock_parse.call_count == 2

--- a/tests/extensions/test_query_transform_cache.py
+++ b/tests/extensions/test_query_transform_cache.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+
+from hiku.readers.graphql import get_operation
+from hiku.extensions.query_transform_cache import QueryTransformCache
+from hiku.types import String
+from hiku.executors.sync import SyncExecutor
+from hiku.engine import Engine
+from hiku.endpoint.graphql import GraphQLEndpoint
+from hiku.graph import Field, Root, Graph
+
+
+@pytest.fixture(name="sync_graph")
+def sync_graph_fixture():
+    def question(fields):
+        return ["Number?" for _ in fields]
+
+    def answer(fields):
+        return ["42" for _ in fields]
+
+    return Graph([Root([
+        Field("question", String, question),
+        Field("answer", String, answer),
+    ])])
+
+
+def test_query_transform_cache_extension(sync_graph):
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[QueryTransformCache(2)],
+    )
+
+    with patch("hiku.readers.graphql.get_operation", wraps=get_operation) as mock_get_operation:
+        result = endpoint.dispatch({"query": "{answer}"})
+        assert result == {"data": {"answer": "42"}}
+
+        assert mock_get_operation.call_count == 1
+
+        for _ in range(3):
+            result = endpoint.dispatch({"query": "{answer}"})
+            assert result == {"data": {"answer": "42"}}
+
+        # check that read_operation was called only once
+        assert mock_get_operation.call_count == 1
+
+        # check that new query was parsed
+        result = endpoint.dispatch({"query": "{question}"})
+        assert result == {"data": {"question": "Number?"}}
+
+        assert mock_get_operation.call_count == 2

--- a/tests/extensions/test_query_validation_cache.py
+++ b/tests/extensions/test_query_validation_cache.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+
+from hiku.validate.query import validate
+from hiku.extensions.query_validation_cache import QueryValidationCache
+from hiku.types import String
+from hiku.executors.sync import SyncExecutor
+from hiku.engine import Engine
+from hiku.endpoint.graphql import GraphQLEndpoint
+from hiku.graph import Field, Root, Graph
+
+
+@pytest.fixture(name="sync_graph")
+def sync_graph_fixture():
+    def question(fields):
+        return ["Number?" for _ in fields]
+
+    def answer(fields):
+        return ["42" for _ in fields]
+
+    return Graph([Root([
+        Field("question", String, question),
+        Field("answer", String, answer),
+    ])])
+
+
+def test_query_validation_cache_extension(sync_graph):
+    endpoint = GraphQLEndpoint(
+        Engine(SyncExecutor()), sync_graph,
+        extensions=[QueryValidationCache(2)],
+    )
+
+    with patch("hiku.endpoint.graphql.validate", wraps=validate) as mock_validate:
+        result = endpoint.dispatch({"query": "{answer}"})
+        assert result == {"data": {"answer": "42"}}
+
+        assert mock_validate.call_count == 1
+
+        for _ in range(3):
+            result = endpoint.dispatch({"query": "{answer}"})
+            assert result == {"data": {"answer": "42"}}
+
+        # check that read_operation was called only once
+        assert mock_validate.call_count == 1
+
+        # check that new query was parsed
+        result = endpoint.dispatch({"query": "{question}"})
+        assert result == {"data": {"question": "Number?"}}
+
+        assert mock_validate.call_count == 2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -663,7 +663,7 @@ def test_cached_link_one__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute(q, graph, ctx=ctx)
+        proxy = engine.execute(graph, q, ctx=ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_product_query(1))
@@ -794,7 +794,7 @@ def test_cached_link_many__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute(q, graph, ctx=ctx)
+        proxy = engine.execute(graph, q, ctx=ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_products_query())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -663,7 +663,7 @@ def test_cached_link_one__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute_query(graph, q, ctx)
+        proxy = engine.execute(q, graph, ctx=ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_product_query(1))
@@ -794,7 +794,7 @@ def test_cached_link_many__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute_query(graph, q, ctx)
+        proxy = engine.execute(q, graph, ctx=ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_products_query())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -663,7 +663,7 @@ def test_cached_link_one__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute(graph, q, ctx)
+        proxy = engine.execute_query(graph, q, ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_product_query(1))
@@ -794,7 +794,7 @@ def test_cached_link_many__sqlalchemy(sync_graph_sqlalchemy):
     ctx = {SA_ENGINE_KEY: sa_engine, "locale": "en"}
 
     def execute(q):
-        proxy = engine.execute(graph, q, ctx)
+        proxy = engine.execute_query(graph, q, ctx)
         return DenormalizeGraphQL(graph, proxy, "query").process(q)
 
     query = read(get_products_query())

--- a/tests/test_endpoint_graphql.py
+++ b/tests/test_endpoint_graphql.py
@@ -6,39 +6,10 @@ from hiku.types import (
 )
 from hiku.engine import Engine
 from hiku.executors.sync import SyncExecutor
-from hiku.readers.graphql import read
-from hiku.endpoint.graphql import _StripQuery, GraphQLEndpoint
+from hiku.endpoint.graphql import GraphQLEndpoint
 from hiku.endpoint.graphql import BatchGraphQLEndpoint, AsyncGraphQLEndpoint
 from hiku.endpoint.graphql import AsyncBatchGraphQLEndpoint
 from hiku.executors.asyncio import AsyncIOExecutor
-
-
-def test_strip():
-    query = read(
-        """
-    query {
-        __typename
-        foo {
-            __typename
-            bar {
-                __typename
-                baz
-            }
-        }
-    }
-    """
-    )
-    assert _StripQuery().visit(query) == read(
-        """
-    query {
-        foo {
-            bar {
-                baz
-            }
-        }
-    }
-    """
-    )
 
 
 @pytest.fixture(name="sync_graph")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -61,7 +61,7 @@ OPTION_BEHAVIOUR = [
 
 def execute(graph, query_, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute_query(graph, query_, ctx)
+    return engine.execute(query_, graph, ctx=ctx)
 
 
 def execute_endpoint(graph, query):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -61,7 +61,7 @@ OPTION_BEHAVIOUR = [
 
 def execute(graph, query_, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute(query_, graph, ctx=ctx)
+    return engine.execute(graph, query_, ctx)
 
 
 def execute_endpoint(graph, query):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,5 @@
 import re
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import (
     List,
     Tuple,
@@ -8,9 +7,6 @@ from typing import (
 )
 
 import pytest
-
-from hiku.context import create_execution_context
-from hiku.readers.graphql import OperationType, read
 
 from hiku.endpoint.graphql import GraphQLEndpoint
 
@@ -27,7 +23,6 @@ from sqlalchemy.pool import StaticPool
 
 from hiku import query as q
 from hiku.denormalize.graphql import DenormalizeGraphQL
-from hiku.executors.threads import ThreadsExecutor
 from hiku.graph import Graph, Interface, Node, Field, Link, Nothing, Option, Root, Union
 from hiku.sources.sqlalchemy import FieldsQuery
 from hiku.types import InterfaceRef, Record, Sequence, Integer, Optional, String, TypeRef, UnionRef

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute_query(graph, query, {})
+    result = engine.execute(query, graph, ctx={})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(graph, query, {})
+    result = engine.execute_query(graph, query, {})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(query, graph, ctx={})
+    result = engine.execute(graph, query, {})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_federation/test_endpoint.py
+++ b/tests/test_federation/test_endpoint.py
@@ -1,4 +1,7 @@
+from typing import Dict
+
 import pytest
+from hiku.graph import Graph
 
 from hiku.executors.asyncio import AsyncIOExecutor
 from hiku.federation.endpoint import (
@@ -14,42 +17,42 @@ from tests.test_federation.utils import (
 )
 
 
-def execute_v1(graph, query_dict):
+def execute_v1(query: Dict, graph: Graph):
     graphql_endpoint = FederatedGraphQLEndpoint(
         Engine(SyncExecutor()),
         graph,
         federation_version=1
     )
 
-    return graphql_endpoint.dispatch(query_dict)
+    return graphql_endpoint.dispatch(query)
 
 
-async def execute_async_v1(graph, query_dict):
+async def execute_async_v1(query: Dict, graph: Graph):
     graphql_endpoint = AsyncFederatedGraphQLEndpoint(
         Engine(AsyncIOExecutor()),
         graph,
         federation_version=1
     )
 
-    return await graphql_endpoint.dispatch(query_dict)
+    return await graphql_endpoint.dispatch(query)
 
 
-def execute_v2(graph, query_dict):
+def execute_v2(query: Dict, graph: Graph):
     graphql_endpoint = FederatedGraphQLEndpoint(
         Engine(SyncExecutor()),
         graph,
     )
 
-    return graphql_endpoint.dispatch(query_dict)
+    return graphql_endpoint.dispatch(query)
 
 
-async def execute_async_v2(graph, query_dict):
+async def execute_async_v2(query: Dict, graph: Graph):
     graphql_endpoint = AsyncFederatedGraphQLEndpoint(
         Engine(AsyncIOExecutor()),
         graph,
     )
 
-    return await graphql_endpoint.dispatch(query_dict)
+    return await graphql_endpoint.dispatch(query)
 
 
 ENTITIES_QUERY = {
@@ -78,7 +81,7 @@ SDL_QUERY = {'query': '{_service {sdl}}'}
     execute_v2,
 ])
 def test_fetch_sdl(executor):
-    result = executor(GRAPH, SDL_QUERY)
+    result = executor(SDL_QUERY, GRAPH)
     assert result['data']['_service']['sdl'] is not None
 
 
@@ -87,7 +90,7 @@ def test_fetch_sdl(executor):
     execute_v2,
 ])
 def test_execute_sync_executor(executor):
-    result = executor(GRAPH, ENTITIES_QUERY)
+    result = executor(ENTITIES_QUERY, GRAPH)
 
     expect = [
         {'status': {'id': 'NEW', 'title': 'new'}},
@@ -102,7 +105,7 @@ def test_execute_sync_executor(executor):
     execute_async_v2,
 ])
 async def test_execute_async_executor(executor):
-    result = await executor(ASYNC_GRAPH, ENTITIES_QUERY)
+    result = await executor(ENTITIES_QUERY, ASYNC_GRAPH)
 
     expect = [
         {'status': {'id': 'NEW', 'title': 'new'}},

--- a/tests/test_federation/test_engine.py
+++ b/tests/test_federation/test_engine.py
@@ -1,4 +1,5 @@
 import pytest
+from hiku.graph import Graph
 
 from hiku.context import create_execution_context
 from hiku.query import Node, Field, Link
@@ -15,14 +16,14 @@ from tests.test_federation.utils import (
 )
 
 
-def execute(graph, query: Node, ctx=None):
+def execute(query: Node, graph: Graph, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute_query(graph, query, ctx=ctx)
+    return engine.execute(query, graph, ctx=ctx)
 
 
-async def execute_async_executor(graph, query: Node, ctx=None):
+async def execute_async(query: Node, graph: Graph, ctx=None):
     engine = Engine(AsyncIOExecutor())
-    return await engine.execute_query(graph, query, ctx=ctx)
+    return await engine.execute(query, graph, ctx=ctx)
 
 
 ENTITIES_QUERY = {
@@ -56,7 +57,7 @@ def test_validate_entities_query():
 
 
 def test_execute_sync_executor():
-    result = execute(GRAPH, QUERY, {})
+    result = execute(QUERY, GRAPH)
     data = denormalize_entities(
         GRAPH,
         QUERY,
@@ -72,7 +73,7 @@ def test_execute_sync_executor():
 
 @pytest.mark.asyncio
 async def test_execute_async_executor():
-    result = await execute_async_executor(ASYNC_GRAPH, QUERY, {})
+    result = await execute_async(QUERY, ASYNC_GRAPH)
     data = denormalize_entities(
         GRAPH,
         QUERY,

--- a/tests/test_federation/test_engine.py
+++ b/tests/test_federation/test_engine.py
@@ -18,12 +18,12 @@ from tests.test_federation.utils import (
 
 def execute(query: Node, graph: Graph, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute(query, graph, ctx=ctx)
+    return engine.execute(graph, query, ctx=ctx)
 
 
 async def execute_async(query: Node, graph: Graph, ctx=None):
     engine = Engine(AsyncIOExecutor())
-    return await engine.execute(query, graph, ctx=ctx)
+    return await engine.execute(graph, query, ctx=ctx)
 
 
 ENTITIES_QUERY = {

--- a/tests/test_federation/test_engine.py
+++ b/tests/test_federation/test_engine.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hiku.context import create_execution_context
 from hiku.query import Node, Field, Link
 from hiku.executors.asyncio import AsyncIOExecutor
 from hiku.federation.endpoint import denormalize_entities
@@ -14,14 +15,14 @@ from tests.test_federation.utils import (
 )
 
 
-def execute(graph, query_, ctx=None):
+def execute(graph, query: Node, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute(graph, query_, ctx=ctx)
+    return engine.execute_query(graph, query, ctx=ctx)
 
 
-async def execute_async_executor(graph, query_, ctx=None):
+async def execute_async_executor(graph, query: Node, ctx=None):
     engine = Engine(AsyncIOExecutor())
-    return await engine.execute(graph, query_, ctx=ctx)
+    return await engine.execute_query(graph, query, ctx=ctx)
 
 
 ENTITIES_QUERY = {

--- a/tests/test_hashable.py
+++ b/tests/test_hashable.py
@@ -23,7 +23,7 @@ def direct_link(ids):
 
 def execute(graph, query_, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute_query(graph, query_, ctx=ctx)
+    return engine.execute(query_, graph, ctx=ctx)
 
 
 def test_link_requires_field_with_unhashable_data():

--- a/tests/test_hashable.py
+++ b/tests/test_hashable.py
@@ -23,7 +23,7 @@ def direct_link(ids):
 
 def execute(graph, query_, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute(query_, graph, ctx=ctx)
+    return engine.execute(graph, query_, ctx=ctx)
 
 
 def test_link_requires_field_with_unhashable_data():

--- a/tests/test_hashable.py
+++ b/tests/test_hashable.py
@@ -23,7 +23,7 @@ def direct_link(ids):
 
 def execute(graph, query_, ctx=None):
     engine = Engine(SyncExecutor())
-    return engine.execute(graph, query_, ctx=ctx)
+    return engine.execute_query(graph, query_, ctx=ctx)
 
 
 def test_link_requires_field_with_unhashable_data():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(query, graph)
+    result = engine.execute(graph, query)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,7 +1,7 @@
 import pytest
-
-from hiku.endpoint.graphql import _StripQuery
 from hiku.denormalize.graphql import DenormalizeGraphQL
+
+from hiku.endpoint.graphql import GraphQLEndpoint
 from hiku.engine import Engine
 from hiku.executors.sync import SyncExecutor
 from hiku.graph import Field, Graph, Interface, Link, Node, Option, Root
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(graph, _StripQuery().visit(query), {})
+    result = engine.execute_query(graph, query)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute_query(graph, query)
+    result = engine.execute(query, graph)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute_query(graph, query, {})
+    result = engine.execute(query, graph, ctx={})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(graph, query, {})
+    result = engine.execute_query(graph, query, {})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -15,7 +15,7 @@ from hiku.validate.graph import GraphValidationError
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(query, graph, ctx={})
+    result = engine.execute(graph, query, ctx={})
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -200,7 +200,7 @@ def _graph():
 
 
 def test_field(engine, graph):
-    result = engine.execute(read("[{:x1s [:a :f]}]"), graph)
+    result = engine.execute(graph, read("[{:x1s [:a :f]}]"))
     check_result(
         result,
         {
@@ -214,7 +214,7 @@ def test_field(engine, graph):
 
 
 def test_field_options(engine, graph):
-    result = engine.execute(read('[{:x1s [(:buz {:size "100"})]}]'), graph)
+    result = engine.execute(graph, read('[{:x1s [(:buz {:size "100"})]}]'))
     check_result(
         result,
         {
@@ -228,7 +228,7 @@ def test_field_options(engine, graph):
 
 
 def test_field_without_options(engine, graph):
-    result = engine.execute(read("[{:x1s [:buz]}]"), graph)
+    result = engine.execute(graph, read("[{:x1s [:buz]}]"))
     check_result(
         result,
         {
@@ -243,12 +243,12 @@ def test_field_without_options(engine, graph):
 
 def test_field_without_required_option(engine, graph):
     with pytest.raises(TypeError) as err:
-        engine.execute(read("[{:x1s [:buz3]}]"), graph)
+        engine.execute(graph, read("[{:x1s [:buz3]}]"))
     err.match('^Required option "size" for (.*)buz3(.*) was not provided$')
 
 
 def test_field_option_defaults(engine, graph):
-    result = engine.execute(read("[{:x1s [:buz2]}]"), graph)
+    result = engine.execute(graph, read("[{:x1s [:buz2]}]"))
     check_result(
         result,
         {
@@ -259,7 +259,7 @@ def test_field_option_defaults(engine, graph):
             ]
         },
     )
-    result = engine.execute(read("[{:x1s [(:buz2 {:size 200})]}]"), graph)
+    result = engine.execute(graph, read("[{:x1s [(:buz2 {:size 200})]}]"))
     check_result(
         result,
         {
@@ -273,7 +273,7 @@ def test_field_option_defaults(engine, graph):
 
 
 def test_sequence_in_arg_type(engine, graph):
-    result = engine.execute(read("[{:x1s [:baz]}]"), graph)
+    result = engine.execute(graph, read("[{:x1s [:baz]}]"))
     check_result(
         result,
         {
@@ -284,7 +284,7 @@ def test_sequence_in_arg_type(engine, graph):
             ]
         },
     )
-    result = engine.execute(read("[{:y1s [:baz]}]"), graph)
+    result = engine.execute(graph, read("[{:y1s [:baz]}]"))
     check_result(
         result,
         {
@@ -299,7 +299,8 @@ def test_sequence_in_arg_type(engine, graph):
 
 def test_mixed_query(engine, graph):
     result = engine.execute(
-        read("[{:x1s [(:with_option {:opt 123}) :a]}]"), graph
+        graph,
+        read("[{:x1s [(:with_option {:opt 123}) :a]}]"),
     )
     check_result(
         result,
@@ -345,5 +346,5 @@ def test_complex_field():
             ),
         ]
     )
-    result = engine.execute(build([Q.foo[Q.a[Q.s]]]), hl_graph)
+    result = engine.execute(hl_graph, build([Q.foo[Q.a[Q.s]]]))
     check_result(result, {"foo": {"a": {"s": "bar"}}})

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -200,7 +200,7 @@ def _graph():
 
 
 def test_field(engine, graph):
-    result = engine.execute_query(graph, read("[{:x1s [:a :f]}]"))
+    result = engine.execute(read("[{:x1s [:a :f]}]"), graph)
     check_result(
         result,
         {
@@ -214,7 +214,7 @@ def test_field(engine, graph):
 
 
 def test_field_options(engine, graph):
-    result = engine.execute_query(graph, read('[{:x1s [(:buz {:size "100"})]}]'))
+    result = engine.execute(read('[{:x1s [(:buz {:size "100"})]}]'), graph)
     check_result(
         result,
         {
@@ -228,7 +228,7 @@ def test_field_options(engine, graph):
 
 
 def test_field_without_options(engine, graph):
-    result = engine.execute_query(graph, read("[{:x1s [:buz]}]"))
+    result = engine.execute(read("[{:x1s [:buz]}]"), graph)
     check_result(
         result,
         {
@@ -243,12 +243,12 @@ def test_field_without_options(engine, graph):
 
 def test_field_without_required_option(engine, graph):
     with pytest.raises(TypeError) as err:
-        engine.execute_query(graph, read("[{:x1s [:buz3]}]"))
+        engine.execute(read("[{:x1s [:buz3]}]"), graph)
     err.match('^Required option "size" for (.*)buz3(.*) was not provided$')
 
 
 def test_field_option_defaults(engine, graph):
-    result = engine.execute_query(graph, read("[{:x1s [:buz2]}]"))
+    result = engine.execute(read("[{:x1s [:buz2]}]"), graph)
     check_result(
         result,
         {
@@ -259,7 +259,7 @@ def test_field_option_defaults(engine, graph):
             ]
         },
     )
-    result = engine.execute_query(graph, read("[{:x1s [(:buz2 {:size 200})]}]"))
+    result = engine.execute(read("[{:x1s [(:buz2 {:size 200})]}]"), graph)
     check_result(
         result,
         {
@@ -273,7 +273,7 @@ def test_field_option_defaults(engine, graph):
 
 
 def test_sequence_in_arg_type(engine, graph):
-    result = engine.execute_query(graph, read("[{:x1s [:baz]}]"))
+    result = engine.execute(read("[{:x1s [:baz]}]"), graph)
     check_result(
         result,
         {
@@ -284,7 +284,7 @@ def test_sequence_in_arg_type(engine, graph):
             ]
         },
     )
-    result = engine.execute_query(graph, read("[{:y1s [:baz]}]"))
+    result = engine.execute(read("[{:y1s [:baz]}]"), graph)
     check_result(
         result,
         {
@@ -298,8 +298,8 @@ def test_sequence_in_arg_type(engine, graph):
 
 
 def test_mixed_query(engine, graph):
-    result = engine.execute_query(
-        graph, read("[{:x1s [(:with_option {:opt 123}) :a]}]")
+    result = engine.execute(
+        read("[{:x1s [(:with_option {:opt 123}) :a]}]"), graph
     )
     check_result(
         result,
@@ -345,5 +345,5 @@ def test_complex_field():
             ),
         ]
     )
-    result = engine.execute_query(hl_graph, build([Q.foo[Q.a[Q.s]]]))
+    result = engine.execute(build([Q.foo[Q.a[Q.s]]]), hl_graph)
     check_result(result, {"foo": {"a": {"s": "bar"}}})

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from hiku.context import create_execution_context
 from hiku.graph import Graph, Node, Link, Field, Option, Root
 from hiku.types import Record, Sequence, Any, TypeRef, String
 from hiku.engine import Engine
@@ -199,7 +200,7 @@ def _graph():
 
 
 def test_field(engine, graph):
-    result = engine.execute(graph, read("[{:x1s [:a :f]}]"))
+    result = engine.execute_query(graph, read("[{:x1s [:a :f]}]"))
     check_result(
         result,
         {
@@ -213,7 +214,7 @@ def test_field(engine, graph):
 
 
 def test_field_options(engine, graph):
-    result = engine.execute(graph, read('[{:x1s [(:buz {:size "100"})]}]'))
+    result = engine.execute_query(graph, read('[{:x1s [(:buz {:size "100"})]}]'))
     check_result(
         result,
         {
@@ -227,7 +228,7 @@ def test_field_options(engine, graph):
 
 
 def test_field_without_options(engine, graph):
-    result = engine.execute(graph, read("[{:x1s [:buz]}]"))
+    result = engine.execute_query(graph, read("[{:x1s [:buz]}]"))
     check_result(
         result,
         {
@@ -242,12 +243,12 @@ def test_field_without_options(engine, graph):
 
 def test_field_without_required_option(engine, graph):
     with pytest.raises(TypeError) as err:
-        engine.execute(graph, read("[{:x1s [:buz3]}]"))
+        engine.execute_query(graph, read("[{:x1s [:buz3]}]"))
     err.match('^Required option "size" for (.*)buz3(.*) was not provided$')
 
 
 def test_field_option_defaults(engine, graph):
-    result = engine.execute(graph, read("[{:x1s [:buz2]}]"))
+    result = engine.execute_query(graph, read("[{:x1s [:buz2]}]"))
     check_result(
         result,
         {
@@ -258,7 +259,7 @@ def test_field_option_defaults(engine, graph):
             ]
         },
     )
-    result = engine.execute(graph, read("[{:x1s [(:buz2 {:size 200})]}]"))
+    result = engine.execute_query(graph, read("[{:x1s [(:buz2 {:size 200})]}]"))
     check_result(
         result,
         {
@@ -272,7 +273,7 @@ def test_field_option_defaults(engine, graph):
 
 
 def test_sequence_in_arg_type(engine, graph):
-    result = engine.execute(graph, read("[{:x1s [:baz]}]"))
+    result = engine.execute_query(graph, read("[{:x1s [:baz]}]"))
     check_result(
         result,
         {
@@ -283,7 +284,7 @@ def test_sequence_in_arg_type(engine, graph):
             ]
         },
     )
-    result = engine.execute(graph, read("[{:y1s [:baz]}]"))
+    result = engine.execute_query(graph, read("[{:y1s [:baz]}]"))
     check_result(
         result,
         {
@@ -297,7 +298,7 @@ def test_sequence_in_arg_type(engine, graph):
 
 
 def test_mixed_query(engine, graph):
-    result = engine.execute(
+    result = engine.execute_query(
         graph, read("[{:x1s [(:with_option {:opt 123}) :a]}]")
     )
     check_result(
@@ -344,5 +345,5 @@ def test_complex_field():
             ),
         ]
     )
-    result = engine.execute(hl_graph, build([Q.foo[Q.a[Q.s]]]))
+    result = engine.execute_query(hl_graph, build([Q.foo[Q.a[Q.s]]]))
     check_result(result, {"foo": {"a": {"s": "bar"}}})

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -3,7 +3,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from hiku.context import create_execution_context
 from hiku.graph import Graph, Node, Link, Field, Option, Root
 from hiku.types import Record, Sequence, Any, TypeRef, String
 from hiku.engine import Engine

--- a/tests/test_source_sqlalchemy.py
+++ b/tests/test_source_sqlalchemy.py
@@ -354,8 +354,7 @@ class TestSourceSQLAlchemy(SourceSQLAlchemyTestBase):
         endpoint = GraphQLEndpoint(
             engine,
             self.graph,
-            get_context=lambda _: {SA_ENGINE_KEY: sa_engine}
         )
 
-        result = endpoint.dispatch({"query": src})
+        result = endpoint.dispatch({"query": src}, context={SA_ENGINE_KEY: sa_engine})
         check_result(result['data'], value)

--- a/tests/test_source_sqlalchemy.py
+++ b/tests/test_source_sqlalchemy.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from hiku.endpoint.graphql import GraphQLEndpoint
 
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
@@ -11,7 +12,6 @@ from sqlalchemy.schema import MetaData, Table, Column, ForeignKey
 from hiku.types import IntegerMeta, StringMeta, TypeRef, Sequence, Optional
 from hiku.graph import Graph, Node, Field, Link, Root
 from hiku.engine import Engine
-from hiku.readers.simple import read
 from hiku.executors.threads import ThreadsExecutor
 from hiku.sources.sqlalchemy import LinkQuery, FieldsQuery
 
@@ -211,7 +211,19 @@ class SourceSQLAlchemyTestBase(ABC):
 
     def test_many_to_one(self):
         self.check(
-            "[{:foo_list [:name :count :bar_id {:bar [:name :type]}]}]",
+            """
+            {
+                foo_list { 
+                    name
+                    count
+                    bar_id
+                    bar {
+                        name
+                        type
+                    }
+                }
+            }
+            """,
             {
                 "foo_list": [
                     {
@@ -233,7 +245,19 @@ class SourceSQLAlchemyTestBase(ABC):
 
     def test_one_to_many(self):
         self.check(
-            "[{:bar_list [:id :name :type {:foo_s [:name :count]}]}]",
+            """
+            {
+                bar_list { 
+                    id
+                    name
+                    type
+                    foo_s {
+                        name
+                        count
+                    }
+                }
+            }
+            """,
             {
                 "bar_list": [
                     {
@@ -268,8 +292,18 @@ class SourceSQLAlchemyTestBase(ABC):
 
     def test_not_found(self):
         self.check(
-            "[{:not_found_one [:name :type]}"
-            " {:not_found_list [:name :type]}]",
+            """
+            {   
+                not_found_one {
+                    name
+                    type
+                }
+                not_found_list {
+                    name
+                    type
+                }
+            }
+            """,
             {
                 "not_found_one": {"name": None, "type": None},
                 "not_found_list": [
@@ -282,7 +316,18 @@ class SourceSQLAlchemyTestBase(ABC):
 
     def test_falsy_one(self):
         self.check(
-            "[{:falsy_one [:name :type {:foo_s [:name :count]}]}]",
+            """
+            {
+                falsy_one {
+                    name
+                    type
+                    foo_s {
+                        name
+                        count
+                    }
+                }
+            }
+            """,
             {
                 "falsy_one": {
                     "name": "bar0",
@@ -306,7 +351,11 @@ class TestSourceSQLAlchemy(SourceSQLAlchemyTestBase):
         setup_db(sa_engine)
 
         engine = Engine(ThreadsExecutor(thread_pool))
-        result = engine.execute(
-            self.graph, read(src), {SA_ENGINE_KEY: sa_engine}
+        endpoint = GraphQLEndpoint(
+            engine,
+            self.graph,
+            get_context=lambda _: {SA_ENGINE_KEY: sa_engine}
         )
-        check_result(result, value)
+
+        result = endpoint.dispatch({"query": src})
+        check_result(result['data'], value)

--- a/tests/test_telemetry_prometheus.py
+++ b/tests/test_telemetry_prometheus.py
@@ -4,7 +4,6 @@ import pytest
 from prometheus_client import REGISTRY
 
 from hiku import query as q
-from hiku.context import create_execution_context
 from hiku.graph import Graph, Node, Field, Link, Root, apply
 from hiku.types import TypeRef
 from hiku.engine import Engine, pass_context
@@ -95,9 +94,7 @@ def test_simple_sync(graph_name, sample_count):
         ]
     )
 
-    execution_context = create_execution_context(query, query_graph=hl_graph)
-
-    result = Engine(SyncExecutor()).execute(execution_context)
+    result = Engine(SyncExecutor()).execute(query, hl_graph)
     check_result(
         result,
         {
@@ -176,7 +173,7 @@ async def test_simple_async(graph_name, sample_count):
     assert sample_count("Root", "x") is None
     assert sample_count("X", "id") is None
 
-    result = await engine.execute_query(hl_graph, query)
+    result = await engine.execute(query, hl_graph)
     check_result(
         result,
         {
@@ -223,8 +220,7 @@ def test_with_pass_context(graph_name, sample_count):
         ]
     )
 
-    execution_context = create_execution_context(query, query_graph=graph)
-    result = Engine(SyncExecutor()).execute(execution_context)
+    result = Engine(SyncExecutor()).execute(query, graph)
     check_result(
         result,
         {

--- a/tests/test_telemetry_prometheus.py
+++ b/tests/test_telemetry_prometheus.py
@@ -94,7 +94,7 @@ def test_simple_sync(graph_name, sample_count):
         ]
     )
 
-    result = Engine(SyncExecutor()).execute(query, hl_graph)
+    result = Engine(SyncExecutor()).execute(hl_graph, query)
     check_result(
         result,
         {
@@ -173,7 +173,7 @@ async def test_simple_async(graph_name, sample_count):
     assert sample_count("Root", "x") is None
     assert sample_count("X", "id") is None
 
-    result = await engine.execute(query, hl_graph)
+    result = await engine.execute(hl_graph, query)
     check_result(
         result,
         {
@@ -220,7 +220,7 @@ def test_with_pass_context(graph_name, sample_count):
         ]
     )
 
-    result = Engine(SyncExecutor()).execute(query, graph)
+    result = Engine(SyncExecutor()).execute(graph, query)
     check_result(
         result,
         {

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,7 +1,7 @@
 import pytest
-from hiku.endpoint.graphql import _StripQuery
-
 from hiku.denormalize.graphql import DenormalizeGraphQL
+
+from hiku.endpoint.graphql import GraphQLEndpoint
 from hiku.engine import Engine
 from hiku.executors.sync import SyncExecutor
 from hiku.graph import Field, Graph, Link, Node, Option, Root, Union
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(graph, _StripQuery().visit(query), {})
+    result = engine.execute_query(graph, query)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute(query, graph)
+    result = engine.execute(graph, query)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -14,7 +14,7 @@ from hiku.validate.query import validate
 
 def execute(graph, query):
     engine = Engine(SyncExecutor())
-    result = engine.execute_query(graph, query)
+    result = engine.execute(query, graph)
     return DenormalizeGraphQL(graph, result, "query").process(query)
 
 

--- a/tests/test_validate_query.py
+++ b/tests/test_validate_query.py
@@ -151,6 +151,14 @@ def test_field_complex(field_name):
     check_errors(q.Node([q.Link(field_name, q.Node([q.Field("attr")]))]), [])
 
 
+def test_field_complex_with_typename():
+    check_errors(
+        q.Node([
+            q.Link('val', q.Node([q.Field('__typename'), q.Field('attr')], []))
+        ]), []
+    )
+
+
 def test_nested_records():
     query = q.Node(
         [

--- a/tests_pg/test_source_aiopg.py
+++ b/tests_pg/test_source_aiopg.py
@@ -35,8 +35,9 @@ class TestSourceAIOPG(SourceSQLAlchemyTestBase):
         sa_engine = await aiopg.sa.create_engine(self.db_dsn, minsize=0)
         engine = Engine(AsyncIOExecutor())
         try:
-            result = await engine.execute(self.graph, read(src),
-                                          {SA_ENGINE_KEY: sa_engine})
+            result = await engine.execute_query(
+                self.graph, read(src), {SA_ENGINE_KEY: sa_engine}
+            )
             check_result(result, value)
         finally:
             sa_engine.close()

--- a/tests_pg/test_source_aiopg.py
+++ b/tests_pg/test_source_aiopg.py
@@ -35,8 +35,8 @@ class TestSourceAIOPG(SourceSQLAlchemyTestBase):
         sa_engine = await aiopg.sa.create_engine(self.db_dsn, minsize=0)
         engine = Engine(AsyncIOExecutor())
         try:
-            result = await engine.execute_query(
-                self.graph, read(src), {SA_ENGINE_KEY: sa_engine}
+            result = await engine.execute(
+                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:

--- a/tests_pg/test_source_sqlalchemy_asyncpg.py
+++ b/tests_pg/test_source_sqlalchemy_asyncpg.py
@@ -37,8 +37,8 @@ class TestSourceSQLAlchemyAsyncPG(SourceSQLAlchemyTestBase):
         sa_engine = create_async_engine(self.db_dsn)
         engine = Engine(AsyncIOExecutor())
         try:
-            result = await engine.execute_query(
-                self.graph, read(src), {SA_ENGINE_KEY: sa_engine}
+            result = await engine.execute(
+                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:

--- a/tests_pg/test_source_sqlalchemy_asyncpg.py
+++ b/tests_pg/test_source_sqlalchemy_asyncpg.py
@@ -37,8 +37,9 @@ class TestSourceSQLAlchemyAsyncPG(SourceSQLAlchemyTestBase):
         sa_engine = create_async_engine(self.db_dsn)
         engine = Engine(AsyncIOExecutor())
         try:
-            result = await engine.execute(self.graph, read(src),
-                                          {SA_ENGINE_KEY: sa_engine})
+            result = await engine.execute_query(
+                self.graph, read(src), {SA_ENGINE_KEY: sa_engine}
+            )
             check_result(result, value)
         finally:
             await greenlet_spawn(sa_engine.sync_engine.dispose)


### PR DESCRIPTION
Adds extension support to Hiku.

- Introduce ExecutionContext to hold all request-related data
- Introduce ExtensionsExecutor which encapsulates execution of extensions during the request lifetime and is responsible for lifetime hooks
- Refactor GraphqlEndpoint
  - support ExecutionContext and ExtensionsExecutor
  - merge batching into GraphqlEndpoint (leave BatchGraphqlEndpoint for compatibility)
  - add the ability to disable introspection
  - add the ability to disable validation
  - add `graph`, `dispatch`, `parsing`,  `operation`, `validation`, and `execution` lifetime hooks
- Add `QueryDepthValidator` extension
- Refactor query cache into the `ParseQueryCache` extension
- Drop `StripQuery` transformer, add support for __typename field, as striped query add unnecessary complexity into execution + adds additional overhead during execution

Повний приклад використання ендпоінту:

```python

endpoint = GraphqlEndpoint(
  engine,
  graph,
  introspection=False,
  batching=True,
  extensions=[QueryParserCache(100)],
)

endpoint.dispatch({'query': query})
# or
endpoint.dispatch([{'query': query}])
```