### PR TITLE
Raise TypeError for nonexistent fragment. Add basic isort config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,8 +38,6 @@ jobs:
         draft: false
         prerelease: ${{ steps.check_version.outputs.PRERELEASE }}
     - name: Set up PDM
-      uses: pdm-project/setup-pdm@v3
-      with:
-        python-version: "3.8"
+      run: pip install pdm==2.10.4
     - name: Publish package distributions to PyPI
       run: pdm publish -u "__token__" -P ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,6 @@ jobs:
     - name: Set up PDM
       uses: pdm-project/setup-pdm@v3
       with:
-        python-version: "3.7"
+        python-version: "3.8"
     - name: Publish package distributions to PyPI
       run: pdm publish -u "__token__" -P ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up PDM
       uses: pdm-project/setup-pdm@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.8"
     - name: Install dependencies
       run: |
         pdm sync -d -G test -G dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,9 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up PDM
-      uses: pdm-project/setup-pdm@v3
-      with:
-        python-version: "3.8"
+      run: pip install pdm==2.10.4
     - name: Install dependencies
       run: |
         pdm sync -d -G test -G dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,3 +251,8 @@ ignore_missing_imports = true
 [tool.black]
 line-length = 80
 target-version = ['py37']
+
+[tool.isort]
+py_version = "37"
+profile = "black"
+line_length = 80

--- a/tests/test_read_graphql.py
+++ b/tests/test_read_graphql.py
@@ -1,11 +1,14 @@
 import pytest
-
 from graphql.language import ast
 from graphql.language.parser import parse
 
-from hiku.query import Fragment, Node, Field, Link
-from hiku.readers.graphql import read, OperationGetter
-from hiku.readers.graphql import read_operation, OperationType
+from hiku.query import Field, Fragment, Link, Node
+from hiku.readers.graphql import (
+    OperationGetter,
+    OperationType,
+    read,
+    read_operation,
+)
 
 
 def check_read(source, query, variables=None):
@@ -281,6 +284,34 @@ def test_reference_cycle_in_fragments():
         """
         )
     err.match('Cyclic fragment usage: "Pakol"')
+
+
+def test_non_existent_fragment_root():
+    with pytest.raises(TypeError) as err:
+        read(
+            """
+        query Pelota {
+          sinope
+          ...Pakol
+        }
+        """
+        )
+    err.match('Undefined fragment: "Pakol"')
+
+
+def test_non_existent_fragment():
+    with pytest.raises(TypeError) as err:
+        read(
+            """
+        query Pelota {
+          sinope
+          pins {
+            ...Splosh
+          }
+        }
+        """
+        )
+    err.match('Undefined fragment: "Splosh"')
 
 
 def test_duplicated_fragment_names():


### PR DESCRIPTION
Fixes queries with non-existent fragments failing with KeyError. Wrapped these with TypeError for correct query validation