### PR TITLE
[fix] add missing UnionRef to federation sdl generation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
   dev:
     <<: *base
     image: hiku-dev
-    
+
   docs:
     <<: *base
     image: hiku-docs
@@ -41,23 +41,23 @@ services:
   examples-federation:
     <<: *examples-base
     command: python3 examples/graphql_federation.py
-    
+
   examples-federation-v2:
     <<: *examples-base
     command: python3 examples/graphql_federation_v2.py
-  
+
   examples-flask:
     <<: *examples-base
-    command: python3 examples/graphql_flask.py  
-              
+    command: python3 examples/graphql_flask.py
+
   examples-aiohttp:
     <<: *examples-base
     command: python3 examples/graphql_aiohttp.py
-    
+
   federation-compatibility-server:
     <<: *examples-base
     entrypoint: pdm run python examples/federation-compatibility/server.py
-    
+
   test-base: &test-base
     <<: *base
     image: hiku-tests

--- a/hiku/federation/sdl.py
+++ b/hiku/federation/sdl.py
@@ -39,6 +39,7 @@ from hiku.graph import (
 from hiku.scalar import ScalarMeta
 from hiku.types import (
     EnumRefMeta,
+    UnionRefMeta,
     IDMeta,
     IntegerMeta,
     MappingMeta,
@@ -100,6 +101,8 @@ def _encode_type(
                 return f"IO{val.__type_name__}"
             return val.__type_name__
         elif isinstance(val, EnumRefMeta):
+            return val.__type_name__
+        elif isinstance(val, UnionRefMeta):
             return val.__type_name__
         elif isinstance(val, ScalarMeta):
             return val.__type_name__

--- a/lets.yaml
+++ b/lets.yaml
@@ -38,7 +38,7 @@ commands:
     description: Build docker image for test
     depends: [_build-base]
     cmd: docker build -t hiku-tests -f Dockerfile --target tests .
-    
+
   _build-dev:
     description: Build docker image for dev
     depends: [_build-base]
@@ -53,7 +53,7 @@ commands:
     description: Run tests
     depends: [_build-tests]
     cmd: [docker-compose, run, --rm, test]
-    
+
   test-tox:
     description: Run tests using tox
     depends: [_build-tests]
@@ -68,7 +68,7 @@ commands:
     description: Run flake8
     depends: [_build-dev]
     cmd: docker-compose run --rm dev pdm run flake
-    
+
   black:
     description: Run flake8
     depends: [_build-dev]
@@ -83,7 +83,7 @@ commands:
     description: Run federation app from examples
     depends: [_build-examples]
     cmd: docker-compose up examples-federation
-    
+
   examples-federation-v2:
     description: Run federation 2 app from examples
     depends: [_build-examples]

--- a/tests/test_federation/test_sdl_v1.py
+++ b/tests/test_federation/test_sdl_v1.py
@@ -5,7 +5,8 @@ from hiku.graph import (
     Field,
     Link,
     Option,
-    Root, Union,
+    Root,
+    Union,
 )
 from hiku.types import (
     Record,
@@ -13,6 +14,7 @@ from hiku.types import (
     String,
     TypeRef,
     Optional,
+    UnionRef,
 )
 from hiku.graph import apply
 
@@ -61,6 +63,15 @@ GRAPH = Graph([
                 Option('id', Integer),
             ],
         ),
+        Link(
+            'bucket',
+            UnionRef['Bucket'],
+            link_resolver,
+            requires=None,
+            options=[
+                Option('id', Integer),
+            ],
+        ),
     ]),
 ], data_types={
     'Status': Record[{
@@ -97,6 +108,7 @@ expected = """
 
     extend type Query {
       order(id: Int!): Order
+      bucket(id: Int!): Bucket!
     }
     
     scalar Any

--- a/tests/test_federation/test_sdl_v2.py
+++ b/tests/test_federation/test_sdl_v2.py
@@ -8,14 +8,18 @@ from hiku.graph import (
     Field,
     Link,
     Option,
-    Root, Union,
+    Root,
+    Union,
 )
 from hiku.types import (
-    Boolean, EnumRef, Record,
+    Boolean,
+    EnumRef,
+    Record,
     Integer,
     String,
     TypeRef,
     Optional,
+    UnionRef,
 )
 from hiku.scalar import Scalar
 from hiku.graph import apply
@@ -80,6 +84,15 @@ GRAPH = Graph([
         Link(
             'order',
             Optional[TypeRef['Order']],
+            link_resolver,
+            requires=None,
+            options=[
+                Option('id', Integer),
+            ],
+        ),
+        Link(
+            'bucket',
+            UnionRef['Bucket'],
             link_resolver,
             requires=None,
             options=[
@@ -153,6 +166,7 @@ expected_tmpl = """
 
     extend type Query {
       order(id: Int!): Order
+      bucket(id: Int!): Bucket!
     }
     %s
     scalar Any
@@ -205,5 +219,4 @@ def test_print_introspected_graph_sdl():
     ])
 
     sdl = print_sdl(INTROSPECTED_GRAPH)
-
     assert sdl.strip() == textwrap.dedent(expected).strip()

--- a/tests_pg/conftest.py
+++ b/tests_pg/conftest.py
@@ -21,7 +21,7 @@ def db_dsn_fixture(request):
     db_dsn = 'postgresql://postgres:postgres@{}:5432/{}'.format(host, name)
 
     pg_engine = sqlalchemy.create_engine(pg_dsn)
-    pg_engine.raw_connection()\
+    pg_engine.raw_connection() \
         .set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     pg_engine.execute('CREATE DATABASE {0}'.format(name))
     pg_engine.dispose()


### PR DESCRIPTION
- add missing `UnionRefMeta` in `hiku/federation/sdl.py` for correct sdl generation with `UnionRef` return type