### PR TITLE
rewrite fragments

### DIFF
--- a/hiku/cache.py
+++ b/hiku/cache.py
@@ -51,7 +51,7 @@ RESULT_CACHE_MISSES = Counter(
     labelnames=["graph", "query_name", "node", "field"],
 )
 
-CACHE_VERSION = "1"
+CACHE_VERSION = "2"
 
 
 class Hasher(Protocol):

--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -34,11 +34,13 @@ from .context import ExecutionContext, create_execution_context
 from .executors.base import SyncAsyncExecutor
 from .operation import Operation, OperationType
 from .query import (
+    Fragment,
     Node as QueryNode,
     Field as QueryField,
     Link as QueryLink,
     QueryTransformer,
     QueryVisitor,
+    merge_links,
 )
 from .graph import (
     FieldType,
@@ -171,10 +173,16 @@ class InitOptions(QueryTransformer):
         return obj.copy(node=node, options=options)
 
 
-# query.Link is considered a complex Field if present in tuple
-FieldGroup = Tuple[Field, Union[QueryField, QueryLink]]
-CallableFieldGroup = Tuple[Callable, Field, Union[QueryField, QueryLink]]
-LinkGroup = Tuple[Link, QueryLink]
+@dataclasses.dataclass
+class FieldInfo:
+    graph_field: Field
+    query_field: Union[QueryField, QueryLink]
+
+
+@dataclasses.dataclass
+class LinkInfo:
+    graph_link: Link
+    query_link: QueryLink
 
 
 class SplitQuery(QueryVisitor):
@@ -184,21 +192,38 @@ class SplitQuery(QueryVisitor):
 
     def __init__(self, graph_node: Node) -> None:
         self._node = graph_node
-        self._fields: List[CallableFieldGroup] = []
-        self._links: List[LinkGroup] = []
+        self.links_map: Dict[str, List[LinkInfo]] = {}
+        self.fields_map: Dict[str, List[Tuple[Callable, FieldInfo]]] = {}
 
-    def split(
-        self, query_node: QueryNode
-    ) -> Tuple[List[CallableFieldGroup], List[LinkGroup]]:
+    def split(self, query_node: QueryNode) -> "SplitQuery":
         for item in query_node.fields:
             self.visit(item)
 
         for fr in query_node.fragments:
-            if fr.type_name != self._node.name:
-                continue
-            self.visit(fr)
+            # node fragments can have different type_names
+            # if node is union or inteface
+            if fr.type_name == self._node.name:
+                self.visit(fr)
 
-        return self._fields, self._links
+        for field, fields in self.fields_map.items():
+            if len(set([f.query_field.index_key for _, f in fields])) > 1:
+                raise ValueError(
+                    f"Can not use same field '{field}' with "
+                    "different arguments."
+                    " Use different field names (aliases) or arguments."
+                )
+
+        for link, links in self.links_map.items():
+            if len(set([ln.query_link.index_key for ln in links])) > 1:
+                raise ValueError(
+                    f"Can not use same field '{field}' with "
+                    "different arguments."
+                    " Use different field names (aliases) or arguments."
+                )
+        return self
+
+    def visit_fragment(self, obj: Fragment) -> None:
+        self.visit(obj.node)
 
     def visit_node(self, obj: QueryNode) -> None:
         for item in obj.fields:
@@ -210,7 +235,9 @@ class SplitQuery(QueryVisitor):
 
         graph_obj = self._node.fields_map[obj.name]
         func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
-        self._fields.append((func, graph_obj, obj))
+        self.fields_map.setdefault(obj.name, []).append(
+            (func, FieldInfo(graph_obj, obj))
+        )
 
     def visit_link(self, obj: QueryLink) -> None:
         graph_obj = self._node.fields_map[obj.name]
@@ -221,24 +248,28 @@ class SplitQuery(QueryVisitor):
                         self.visit(QueryField(r))
                 else:
                     self.visit(QueryField(graph_obj.requires))
-            self._links.append((graph_obj, obj))
+            self.links_map.setdefault(obj.name, []).append(
+                LinkInfo(graph_link=graph_obj, query_link=obj)
+            )
         else:
             assert isinstance(graph_obj, Field), type(graph_obj)
             # `obj` here is a link, but this link is treated as a complex field
             func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
-            self._fields.append((func, graph_obj, obj))
+            self.fields_map.setdefault(obj.name, []).append(
+                (func, FieldInfo(graph_obj, obj))
+            )
 
 
 class GroupQuery(QueryVisitor):
     def __init__(self, node: Node) -> None:
         self._node = node
         self._funcs: List[Callable] = []
-        self._groups: List[Union[List[FieldGroup], LinkGroup]] = []
+        self._groups: List[Union[List[FieldInfo], LinkInfo]] = []
         self._current_func = None
 
     def group(
         self, node: QueryNode
-    ) -> List[Tuple[Callable, Union[List[FieldGroup], LinkGroup]]]:
+    ) -> List[Tuple[Callable, Union[List[FieldInfo], LinkInfo]]]:
         for item in node.fields:
             self.visit(item)
         return list(zip(self._funcs, self._groups))
@@ -251,9 +282,9 @@ class GroupQuery(QueryVisitor):
         func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
         if func == self._current_func:
             assert isinstance(self._groups[-1], list)
-            self._groups[-1].append((graph_obj, obj))
+            self._groups[-1].append(FieldInfo(graph_obj, obj))
         else:
-            self._groups.append([(graph_obj, obj)])
+            self._groups.append([FieldInfo(graph_obj, obj)])
             self._funcs.append(func)
             self._current_func = func
 
@@ -265,7 +296,7 @@ class GroupQuery(QueryVisitor):
                     self.visit(QueryField(r))
             else:
                 self.visit(QueryField(graph_obj.requires))
-        self._groups.append((graph_obj, obj))
+        self._groups.append(LinkInfo(graph_obj, obj))
         self._funcs.append(graph_obj.func)
         self._current_func = None
 
@@ -645,7 +676,9 @@ class Query(Workflow):
         proc_steps = GroupQuery(node).group(query)
 
         # recursively and sequentially schedule fields and links
-        def proc(steps: List) -> None:
+        def proc(
+            steps: List[Tuple[Callable, Union[List[FieldInfo], LinkInfo]]]
+        ) -> None:
             step_func, step_item = steps.pop(0)
             if isinstance(step_item, list):
                 self._track(path)
@@ -653,10 +686,9 @@ class Query(Workflow):
                     path, node, step_func, step_item, ids
                 )
             else:
-                graph_link, query_link = step_item
                 self._track(path)
                 dep = self._schedule_link(
-                    path, node, graph_link, query_link, ids
+                    path, node, step_item.graph_link, step_item.query_link, ids
                 )
 
             if steps:
@@ -679,27 +711,38 @@ class Query(Workflow):
             self._process_node_ordered(path, node, query, ids)
             return
 
-        fields, links = SplitQuery(node).split(query)
+        fields = SplitQuery(node).split(query)
 
         to_func: Dict[str, Callable] = {}
-        from_func: DefaultDict[Callable, List[FieldGroup]] = defaultdict(list)
-        for func, graph_field, query_field in fields:
-            to_func[graph_field.name] = func
-            from_func[func].append((graph_field, query_field))
+        from_func: DefaultDict[Callable, List[FieldInfo]] = defaultdict(list)
+        for field_name, fields_info in fields.fields_map.items():
+            func, field_info = fields_info[0]
+            to_func[field_info.graph_field.name] = func
+            from_func[func].append(field_info)
 
-        # schedule fields resolve
         to_dep: Dict[Callable, Dep] = {}
-        for func, func_fields in from_func.items():
+        for func, func_fields_info in from_func.items():
             self._track(path)
             to_dep[func] = self._schedule_fields(
-                path, node, func, func_fields, ids
+                path, node, func, func_fields_info, ids
             )
 
         # schedule link resolve
-        for graph_link, query_link in links:
+        for link_name, links_info in fields.links_map.items():
+            query_links = [info.query_link for info in links_info]
+            graph_link = links_info[0].graph_link
+
+            # recursively we collect and resolve leaf fields of all links fields
+            link = merge_links(query_links)
+
             self._track(path)
             schedule = partial(
-                self._schedule_link, path, node, graph_link, query_link, ids
+                self._schedule_link,
+                path,
+                node,
+                graph_link,
+                link,
+                ids,
             )
             if graph_link.requires:
                 if isinstance(graph_link.requires, list):
@@ -787,15 +830,16 @@ class Query(Workflow):
         path: NodePath,
         node: Node,
         func: Callable,
-        fields: List[FieldGroup],
+        fields_info: List[FieldInfo],
         ids: Optional[Any],
     ) -> Union[SubmitRes, TaskSet]:
-        query_fields = [qf for _, qf in fields]
+        query_fields = [f.query_field for f in fields_info]
 
         dep: Union[TaskSet, SubmitRes]
         if hasattr(func, "__subquery__"):
             assert ids is not None
             dep = self._queue.fork(self._task_set)
+            fields = [(f.graph_field, f.query_field) for f in fields_info]
             proc = func(fields, ids, self._queue, self._ctx, dep)
         else:
             if ids is None:
@@ -854,7 +898,12 @@ class Query(Workflow):
 
             if ids:
                 self._schedule_link(
-                    path, node, graph_link, query_link, ids, skip_cache=True
+                    path,
+                    node,
+                    graph_link,
+                    query_link,
+                    ids,
+                    skip_cache=True,
                 )
 
         self._queue.add_callback(dep, callback)
@@ -882,13 +931,14 @@ class Query(Workflow):
         """
         args = []
         if graph_link.requires:
+            # collect data for link requires from store
             reqs: Any = link_reqs(self._index, node, graph_link, ids)
 
             if (
                 "cached" in query_link.directives_map
                 and self._cache
                 and not skip_cache
-            ):  # noqa: E501
+            ):
                 return self._update_index_from_cache(
                     path, node, graph_link, query_link, ids, reqs
                 )
@@ -902,7 +952,12 @@ class Query(Workflow):
 
         def callback() -> None:
             return self.process_link(
-                path, node, graph_link, query_link, ids, dep.result()
+                path,
+                node,
+                graph_link,
+                query_link,
+                ids,
+                dep.result(),
             )
 
         self._queue.add_callback(dep, callback)

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -96,15 +96,6 @@ class Proxy:
                     "Field {!r} wasn't requested in the query".format(item)
                 )
 
-            try:
-                field = self.__node__.fragments_map[
-                    self.__ref__.node
-                ].node.result_map[item]
-            except KeyError:
-                raise KeyError(
-                    "Field {!r} wasn't requested in the query".format(item)
-                )
-
         try:
             obj: t.Dict = self.__idx__[self.__ref__.node][self.__ref__.ident]
         except KeyError:

--- a/hiku/sources/graph.py
+++ b/hiku/sources/graph.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import (
     NoReturn,
     List,
+    Tuple,
     Union,
     Callable,
     Iterator,
@@ -21,11 +22,15 @@ from ..graph import (
     Field,
 )
 from ..types import TypeRef, Sequence
-from ..query import merge, Node as QueryNode, Field as QueryField
+from ..query import (
+    merge,
+    Node as QueryNode,
+    Field as QueryField,
+    Link as QueryLink,
+)
 from ..types import Any
 from ..engine import (
     Query,
-    FieldGroup,
     Context,
 )
 from ..expr.refs import RequirementsExtractor
@@ -40,6 +45,7 @@ from ..expr.checker import check, fn_types
 from ..expr.compiler import ExpressionCompiler
 
 
+FieldGroup = Tuple[Field, Union[QueryField, QueryLink]]
 Expr: TypeAlias = Union[_Func, DotHandler]
 
 
@@ -176,7 +182,12 @@ class SubGraph:
 
         q = Query(queue, task_set, self.graph, reqs, ctx)
         q.process_link(
-            path, self.graph.root, this_graph_link, this_query_link, None, ids
+            path,
+            self.graph.root,
+            this_graph_link,
+            this_query_link,
+            None,
+            ids,
         )
         q.process_node(path, self.graph.root, other_reqs, None)
         return _create_result_proc(q, procs, option_values)

--- a/tests/benchmarks/test_read_graphql.py
+++ b/tests/benchmarks/test_read_graphql.py
@@ -51,7 +51,7 @@ def test_link_fragment(benchmark):
                 Field("id"),
             ],
             [
-                Fragment("User", [
+                Fragment(None, "User", [
                     Field("name"),
                 ])
             ]

--- a/tests/test_federation/test_engine.py
+++ b/tests/test_federation/test_engine.py
@@ -1,7 +1,6 @@
 import pytest
 from hiku.graph import Graph
 
-from hiku.context import create_execution_context
 from hiku.query import Node, Field, Link
 from hiku.executors.asyncio import AsyncIOExecutor
 from hiku.federation.endpoint import denormalize_entities
@@ -43,7 +42,6 @@ ENTITIES_QUERY = {
         ]
     }
 }
-QUERY = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
 
 
 SDL_QUERY = Node(fields=[
@@ -52,15 +50,17 @@ SDL_QUERY = Node(fields=[
 
 
 def test_validate_entities_query():
-    errors = validate(GRAPH, QUERY)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    errors = validate(GRAPH, query)
     assert errors == []
 
 
 def test_execute_sync_executor():
-    result = execute(QUERY, GRAPH)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    result = execute(query, GRAPH)
     data = denormalize_entities(
         GRAPH,
-        QUERY,
+        query,
         result,
     )
 
@@ -73,10 +73,11 @@ def test_execute_sync_executor():
 
 @pytest.mark.asyncio
 async def test_execute_async_executor():
-    result = await execute_async(QUERY, ASYNC_GRAPH)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    result = await execute_async(query, ASYNC_GRAPH)
     data = denormalize_entities(
         GRAPH,
-        QUERY,
+        query,
         result,
     )
 

--- a/tests/test_read_graphql.py
+++ b/tests/test_read_graphql.py
@@ -190,7 +190,14 @@ def test_named_fragments() -> None:
                     Node([Field("rusk")]),
                 ),
             ],
-            [],
+            [
+                Fragment("Meer", 'Torsion', [
+                    Link(
+                        "kilned",
+                        Node([Field("rusk")]),
+                    ),
+                ]),
+            ],
         ),
     )
 
@@ -202,7 +209,7 @@ def test_named_fragments() -> None:
                 Field("apres"),
             ],
             [
-                Fragment('Makai', [
+                Fragment("Goaded", 'Makai', [
                     Field("doozie"),
                     PinsLink
                 ]),
@@ -218,7 +225,7 @@ def test_named_fragments() -> None:
                 SneezerLink
             ],
             [
-                Fragment("Valium", [
+                Fragment(None, "Valium", [
                     Link(
                         "movies",
                         Node([Field("boree")]),
@@ -599,12 +606,14 @@ def test_parse_union_with_two_fragments():
                     Node([
                         Field("__typename"),
                         ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("id"),
                             Field("duration"),
                         ]),
-                        Fragment('Video', [
+                        Fragment('VideoId', 'Video', [
                             Field("id"),
+                        ]),
+                        Fragment(None, 'Video', [
                             Field("thumbnailUrl"),
                         ]),
                     ]),
@@ -634,7 +643,7 @@ def test_parse_union_with_one_fragment():
                     Node([
                         Field("__typename"),
                     ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("id"),
                             Field("duration"),
                         ]),
@@ -672,10 +681,10 @@ def test_parse_interface_with_two_fragments():
                         Field("id"),
                         Field("duration"),
                         ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("album"),
                         ]),
-                        Fragment('Video', [
+                        Fragment(None, 'Video', [
                             Field("thumbnailUrl"),
                         ]),
                     ])
@@ -708,7 +717,7 @@ def test_parse_interface_with_one_fragment():
                         Field("id"),
                         Field("duration"),
                     ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("album"),
                         ]),
                     ]),
@@ -752,11 +761,21 @@ def test_merge_node_with_fragment_on_node() -> None:
                             Field("id"),
                             Field("name"),
                         ], [
-                            Fragment('User', [
+                            Fragment(None, 'User', [
+                                Field("id"),
                                 Field("email"),
                             ]),
                         ])),
-                    ], []),
+                    ], [
+                        Fragment(None, 'Context', [
+                            Link("user", Node([], [
+                                Fragment(None, 'User', [
+                                    Field("id"),
+                                    Field("email"),
+                                ]),
+                            ])),
+                        ]),
+                    ]),
                 )
             ]
         ),
@@ -799,11 +818,21 @@ def test_merge_fragment_for_union() -> None:
                             Field("id"),
                             Field("name"),
                         ], [
-                            Fragment('User', [
+                            Fragment(None, 'User', [
+                                Field("id"),
                                 Field("email"),
                             ]),
                         ])),
-                    ], []),
+                    ], [
+                        Fragment(None, 'Context', [
+                            Link("user", Node([], [
+                                Fragment(None, 'User', [
+                                    Field("id"),
+                                    Field("email"),
+                                ]),
+                            ])),
+                        ]),
+                    ]),
                 )
             ]
         ),

--- a/tests_pg/test_source_aiopg.py
+++ b/tests_pg/test_source_aiopg.py
@@ -5,7 +5,7 @@ import aiopg.sa
 import hiku.sources.aiopg
 
 from hiku.engine import Engine
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.asyncio import AsyncIOExecutor
 
 from tests.base import check_result
@@ -36,7 +36,7 @@ class TestSourceAIOPG(SourceSQLAlchemyTestBase):
         engine = Engine(AsyncIOExecutor())
         try:
             result = await engine.execute(
-                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
+                self.graph, read(src), ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:

--- a/tests_pg/test_source_sqlalchemy_asyncpg.py
+++ b/tests_pg/test_source_sqlalchemy_asyncpg.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 import hiku.sources.sqlalchemy_async
 
 from hiku.engine import Engine
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.asyncio import AsyncIOExecutor
 
 from tests.base import check_result
@@ -38,7 +38,7 @@ class TestSourceSQLAlchemyAsyncPG(SourceSQLAlchemyTestBase):
         engine = Engine(AsyncIOExecutor())
         try:
             result = await engine.execute(
-                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
+                self.graph, read(src), ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:


### PR DESCRIPTION
In this PR we addressed the issue with broken fragments merging. Historically, hiku had no support for unions/interfaces so fragment merging was ok. But things went in the wrong direction after we added unions/interfaces support + fragments support.

Fragments merging (fields merging to be more accurate) has its rules in graphql spec, and we did not comply to them. So why thought ?

Hiku architecture was built without fragments in mind, that is - engine and denormalization modules could not work with fragments. So to avoid complex rewriting of the engine and denormalization modules, we decided to merge fragments to avoid field duplication - the hardest thing to support in the engine.

In this PR, we try to mimic graphql-py behavior or merging fields:
- We removed complex merging in query parsing step, now all fields and fragments are stored in hiku ast as is
- In engine we adapted SplitQuery to group fields and link:
  - Fields are leaf nodes so it is safe to take first field from fields_info (list of field instances) as long as field args are the same
  - Same link is collected and will be merged before `schedule_link` call, so that no duplicated links will be processed
  - Cache works as previous but hashes are changed sihce link node fields are merged
  - Denormalize adapted to work with links/fields resolved multiple times and checks that field already presents in result skipping its serialization

So basically we moved handling of fields merging to engine/denormalization stage and simplified parsing.

Some other changes:
 - Refactor SplitQuery types, introduce FieldInfo and LinkInfo instead of tuples
 - Refactor GroupQuery to use FieldInfo/LinkInfo
 - Fix cache tests
 - Drop fragments hack from result.py:Proxy since we now provide proper Proxy to index for each fragment
 - Add name for Fragment, if name is None - this is an InlineFragment
 - Node.fragments_map only returns named fragments map