### PR TITLE
Rewrite fragments merge

### DIFF
--- a/hiku/cache.py
+++ b/hiku/cache.py
@@ -51,7 +51,7 @@ RESULT_CACHE_MISSES = Counter(
     labelnames=["graph", "query_name", "node", "field"],
 )
 
-CACHE_VERSION = "1"
+CACHE_VERSION = "2"
 
 
 class Hasher(Protocol):

--- a/hiku/denormalize/base.py
+++ b/hiku/denormalize/base.py
@@ -77,7 +77,7 @@ class Denormalize(QueryVisitor):
         for i, fr in enumerate(obj.fragments):
             self.visit_fragment(fr, i)
 
-    def visit_fragment(self, obj: Fragment, idx: int) -> None:
+    def visit_fragment(self, obj: Fragment, idx: int) -> None:  # type: ignore[override]  # noqa: E501
         type_name = None
         if isinstance(self._data[-1], Proxy):
             type_name = self._data[-1].__ref__.node
@@ -105,10 +105,9 @@ class Denormalize(QueryVisitor):
                 node = self._graph.nodes_map[type_name]
             graph_field = node.fields_map[obj.name]
 
-            if obj.result_key not in self._res[-1]:
-                self._res[-1][obj.result_key] = serialize_value(
-                    self._graph, graph_field, self._data[-1][obj.result_key]
-                )
+            self._res[-1][obj.result_key] = serialize_value(
+                self._graph, graph_field, self._data[-1][obj.result_key]
+            )
         else:
             # Record type itself does not have custom serialization
             # TODO: support Scalar/Enum types in Record
@@ -126,13 +125,7 @@ class Denormalize(QueryVisitor):
 
         if isinstance(type_, RefMeta):
             self._type.append(get_type(self._types, type_))
-            # if we already visited this link, just reuse the result
-            if obj.result_key not in self._res[-1]:
-                self._res.append({})
-            else:
-                res = self._res[-1][obj.result_key]
-                self._res.append(res)
-
+            self._res.append({})
             self._data.append(self._data[-1][obj.result_key])
             super().visit_link(obj)
             self._data.pop()

--- a/hiku/denormalize/base.py
+++ b/hiku/denormalize/base.py
@@ -74,10 +74,10 @@ class Denormalize(QueryVisitor):
         for item in obj.fields:
             self.visit(item)
 
-        for fr in obj.fragments:
-            self.visit_fragment(fr)
+        for i, fr in enumerate(obj.fragments):
+            self.visit_fragment(fr, i)
 
-    def visit_fragment(self, obj: Fragment) -> None:
+    def visit_fragment(self, obj: Fragment, idx: int) -> None:
         type_name = None
         if isinstance(self._data[-1], Proxy):
             type_name = self._data[-1].__ref__.node
@@ -87,9 +87,9 @@ class Denormalize(QueryVisitor):
             return
 
         if isinstance(self._data[-1], Proxy):
-            self._data.append(
-                Proxy(self._index, self._data[-1].__ref__, obj.node)
-            )
+            node = self._data[-1].__node__.fragments[idx].node
+            ref = self._data[-1].__ref__
+            self._data.append(Proxy(self._index, ref, node))
         else:
             self._data.append(self._data[-1])
         for item in obj.node.fields:

--- a/hiku/endpoint/graphql.py
+++ b/hiku/endpoint/graphql.py
@@ -5,6 +5,7 @@ from asyncio import gather
 
 from typing_extensions import TypedDict
 
+from hiku.merge import QueryMerger
 from hiku.graph import GraphTransformer
 
 from hiku.result import Proxy
@@ -159,6 +160,10 @@ class BaseGraphQLEndpoint(ABC, t.Generic[C]):
                     )
 
             execution_context.query = execution_context.operation.query
+
+            # TODO: move this into read operation
+            collector = QueryMerger(execution_context.graph)
+            execution_context.query = collector.merge(execution_context.query)
 
         op = execution_context.operation
         if op.type not in (OperationType.QUERY, OperationType.MUTATION):

--- a/hiku/endpoint/graphql.py
+++ b/hiku/endpoint/graphql.py
@@ -162,8 +162,8 @@ class BaseGraphQLEndpoint(ABC, t.Generic[C]):
             execution_context.query = execution_context.operation.query
 
             # TODO: move this into read operation
-            collector = QueryMerger(execution_context.graph)
-            execution_context.query = collector.merge(execution_context.query)
+            merger = QueryMerger(execution_context.graph)
+            execution_context.query = merger.merge(execution_context.query)
 
         op = execution_context.operation
         if op.type not in (OperationType.QUERY, OperationType.MUTATION):

--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -34,11 +34,13 @@ from .context import ExecutionContext, create_execution_context
 from .executors.base import SyncAsyncExecutor
 from .operation import Operation, OperationType
 from .query import (
+    Fragment,
     Node as QueryNode,
     Field as QueryField,
     Link as QueryLink,
     QueryTransformer,
     QueryVisitor,
+    merge_links,
 )
 from .graph import (
     FieldType,
@@ -171,10 +173,16 @@ class InitOptions(QueryTransformer):
         return obj.copy(node=node, options=options)
 
 
-# query.Link is considered a complex Field if present in tuple
-FieldGroup = Tuple[Field, Union[QueryField, QueryLink]]
-CallableFieldGroup = Tuple[Callable, Field, Union[QueryField, QueryLink]]
-LinkGroup = Tuple[Link, QueryLink]
+@dataclasses.dataclass
+class FieldInfo:
+    graph_field: Field
+    query_field: Union[QueryField, QueryLink]
+
+
+@dataclasses.dataclass
+class LinkInfo:
+    graph_link: Link
+    query_link: QueryLink
 
 
 class SplitQuery(QueryVisitor):
@@ -184,21 +192,38 @@ class SplitQuery(QueryVisitor):
 
     def __init__(self, graph_node: Node) -> None:
         self._node = graph_node
-        self._fields: List[CallableFieldGroup] = []
-        self._links: List[LinkGroup] = []
+        self.links_map: Dict[str, List[LinkInfo]] = {}
+        self.fields_map: Dict[str, List[Tuple[Callable, FieldInfo]]] = {}
 
-    def split(
-        self, query_node: QueryNode
-    ) -> Tuple[List[CallableFieldGroup], List[LinkGroup]]:
+    def split(self, query_node: QueryNode) -> "SplitQuery":
         for item in query_node.fields:
             self.visit(item)
 
         for fr in query_node.fragments:
-            if fr.type_name != self._node.name:
-                continue
-            self.visit(fr)
+            # node fragments can have different type_names
+            # if node is union or inteface
+            if fr.type_name == self._node.name:
+                self.visit(fr)
 
-        return self._fields, self._links
+        for field, fields in self.fields_map.items():
+            if len(set([f.query_field.index_key for _, f in fields])) > 1:
+                raise ValueError(
+                    f"Can not use same field '{field}' with "
+                    "different arguments."
+                    " Use different field names (aliases) or arguments."
+                )
+
+        for link, links in self.links_map.items():
+            if len(set([ln.query_link.index_key for ln in links])) > 1:
+                raise ValueError(
+                    f"Can not use same field '{field}' with "
+                    "different arguments."
+                    " Use different field names (aliases) or arguments."
+                )
+        return self
+
+    def visit_fragment(self, obj: Fragment) -> None:
+        self.visit(obj.node)
 
     def visit_node(self, obj: QueryNode) -> None:
         for item in obj.fields:
@@ -210,7 +235,9 @@ class SplitQuery(QueryVisitor):
 
         graph_obj = self._node.fields_map[obj.name]
         func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
-        self._fields.append((func, graph_obj, obj))
+        self.fields_map.setdefault(obj.name, []).append(
+            (func, FieldInfo(graph_obj, obj))
+        )
 
     def visit_link(self, obj: QueryLink) -> None:
         graph_obj = self._node.fields_map[obj.name]
@@ -221,24 +248,28 @@ class SplitQuery(QueryVisitor):
                         self.visit(QueryField(r))
                 else:
                     self.visit(QueryField(graph_obj.requires))
-            self._links.append((graph_obj, obj))
+            self.links_map.setdefault(obj.name, []).append(
+                LinkInfo(graph_link=graph_obj, query_link=obj)
+            )
         else:
             assert isinstance(graph_obj, Field), type(graph_obj)
             # `obj` here is a link, but this link is treated as a complex field
             func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
-            self._fields.append((func, graph_obj, obj))
+            self.fields_map.setdefault(obj.name, []).append(
+                (func, FieldInfo(graph_obj, obj))
+            )
 
 
 class GroupQuery(QueryVisitor):
     def __init__(self, node: Node) -> None:
         self._node = node
         self._funcs: List[Callable] = []
-        self._groups: List[Union[List[FieldGroup], LinkGroup]] = []
+        self._groups: List[Union[List[FieldInfo], LinkInfo]] = []
         self._current_func = None
 
     def group(
         self, node: QueryNode
-    ) -> List[Tuple[Callable, Union[List[FieldGroup], LinkGroup]]]:
+    ) -> List[Tuple[Callable, Union[List[FieldInfo], LinkInfo]]]:
         for item in node.fields:
             self.visit(item)
         return list(zip(self._funcs, self._groups))
@@ -251,9 +282,9 @@ class GroupQuery(QueryVisitor):
         func = getattr(graph_obj.func, "__subquery__", graph_obj.func)
         if func == self._current_func:
             assert isinstance(self._groups[-1], list)
-            self._groups[-1].append((graph_obj, obj))
+            self._groups[-1].append(FieldInfo(graph_obj, obj))
         else:
-            self._groups.append([(graph_obj, obj)])
+            self._groups.append([FieldInfo(graph_obj, obj)])
             self._funcs.append(func)
             self._current_func = func
 
@@ -265,7 +296,7 @@ class GroupQuery(QueryVisitor):
                     self.visit(QueryField(r))
             else:
                 self.visit(QueryField(graph_obj.requires))
-        self._groups.append((graph_obj, obj))
+        self._groups.append(LinkInfo(graph_obj, obj))
         self._funcs.append(graph_obj.func)
         self._current_func = None
 
@@ -645,7 +676,9 @@ class Query(Workflow):
         proc_steps = GroupQuery(node).group(query)
 
         # recursively and sequentially schedule fields and links
-        def proc(steps: List) -> None:
+        def proc(
+            steps: List[Tuple[Callable, Union[List[FieldInfo], LinkInfo]]]
+        ) -> None:
             step_func, step_item = steps.pop(0)
             if isinstance(step_item, list):
                 self._track(path)
@@ -653,10 +686,9 @@ class Query(Workflow):
                     path, node, step_func, step_item, ids
                 )
             else:
-                graph_link, query_link = step_item
                 self._track(path)
                 dep = self._schedule_link(
-                    path, node, graph_link, query_link, ids
+                    path, node, step_item.graph_link, step_item.query_link, ids
                 )
 
             if steps:
@@ -679,27 +711,38 @@ class Query(Workflow):
             self._process_node_ordered(path, node, query, ids)
             return
 
-        fields, links = SplitQuery(node).split(query)
+        fields = SplitQuery(node).split(query)
 
         to_func: Dict[str, Callable] = {}
-        from_func: DefaultDict[Callable, List[FieldGroup]] = defaultdict(list)
-        for func, graph_field, query_field in fields:
-            to_func[graph_field.name] = func
-            from_func[func].append((graph_field, query_field))
+        from_func: DefaultDict[Callable, List[FieldInfo]] = defaultdict(list)
+        for field_name, fields_info in fields.fields_map.items():
+            func, field_info = fields_info[0]
+            to_func[field_info.graph_field.name] = func
+            from_func[func].append(field_info)
 
-        # schedule fields resolve
         to_dep: Dict[Callable, Dep] = {}
-        for func, func_fields in from_func.items():
+        for func, func_fields_info in from_func.items():
             self._track(path)
             to_dep[func] = self._schedule_fields(
-                path, node, func, func_fields, ids
+                path, node, func, func_fields_info, ids
             )
 
         # schedule link resolve
-        for graph_link, query_link in links:
+        for link_name, links_info in fields.links_map.items():
+            query_links = [info.query_link for info in links_info]
+            graph_link = links_info[0].graph_link
+
+            # recursively we collect and resolve leaf fields of all links fields
+            link = merge_links(query_links)
+
             self._track(path)
             schedule = partial(
-                self._schedule_link, path, node, graph_link, query_link, ids
+                self._schedule_link,
+                path,
+                node,
+                graph_link,
+                link,
+                ids,
             )
             if graph_link.requires:
                 if isinstance(graph_link.requires, list):
@@ -787,15 +830,16 @@ class Query(Workflow):
         path: NodePath,
         node: Node,
         func: Callable,
-        fields: List[FieldGroup],
+        fields_info: List[FieldInfo],
         ids: Optional[Any],
     ) -> Union[SubmitRes, TaskSet]:
-        query_fields = [qf for _, qf in fields]
+        query_fields = [f.query_field for f in fields_info]
 
         dep: Union[TaskSet, SubmitRes]
         if hasattr(func, "__subquery__"):
             assert ids is not None
             dep = self._queue.fork(self._task_set)
+            fields = [(f.graph_field, f.query_field) for f in fields_info]
             proc = func(fields, ids, self._queue, self._ctx, dep)
         else:
             if ids is None:
@@ -854,7 +898,12 @@ class Query(Workflow):
 
             if ids:
                 self._schedule_link(
-                    path, node, graph_link, query_link, ids, skip_cache=True
+                    path,
+                    node,
+                    graph_link,
+                    query_link,
+                    ids,
+                    skip_cache=True,
                 )
 
         self._queue.add_callback(dep, callback)
@@ -882,13 +931,14 @@ class Query(Workflow):
         """
         args = []
         if graph_link.requires:
+            # collect data for link requires from store
             reqs: Any = link_reqs(self._index, node, graph_link, ids)
 
             if (
                 "cached" in query_link.directives_map
                 and self._cache
                 and not skip_cache
-            ):  # noqa: E501
+            ):
                 return self._update_index_from_cache(
                     path, node, graph_link, query_link, ids, reqs
                 )
@@ -902,7 +952,12 @@ class Query(Workflow):
 
         def callback() -> None:
             return self.process_link(
-                path, node, graph_link, query_link, ids, dep.result()
+                path,
+                node,
+                graph_link,
+                query_link,
+                ids,
+                dep.result(),
             )
 
         self._queue.add_callback(dep, callback)

--- a/hiku/federation/endpoint.py
+++ b/hiku/federation/endpoint.py
@@ -166,6 +166,14 @@ class BaseFederatedGraphEndpoint(BaseGraphQLEndpoint):
         else:
             self.mutation_graph = None
 
+    def _validate(
+        self,
+        graph: GraphT,
+        query: Node,
+        validators: Optional[Tuple[QueryValidator, ...]] = None,
+    ) -> List[str]:
+        return _run_validation(graph, query, validators)
+
 
 class BaseSyncFederatedGraphQLEndpoint(BaseFederatedGraphEndpoint):
     @abstractmethod
@@ -258,17 +266,6 @@ class FederatedGraphQLEndpoint(BaseSyncFederatedGraphQLEndpoint):
         extensions_manager: ExtensionsManager,
     ) -> Dict:
         execution_context = cast(ExecutionContextFinal, execution_context)
-
-        with extensions_manager.validation():
-            if self.validation and execution_context.errors is None:
-                execution_context.errors = _run_validation(
-                    execution_context.graph,
-                    execution_context.query,
-                    execution_context.validators,
-                )
-
-        if execution_context.errors:
-            raise GraphQLError(errors=execution_context.errors)
 
         with extensions_manager.execution():
             if "_service" in execution_context.query.fields_map:

--- a/hiku/merge.py
+++ b/hiku/merge.py
@@ -1,0 +1,187 @@
+from collections import deque
+from contextlib import contextmanager
+import typing as t
+
+from collections.abc import Sequence
+
+from hiku.enum import BaseEnum
+from hiku.graph import Graph, Interface, Link as GraphLink, LinkType, Union
+from hiku.query import Link, Field, Fragment, Node, QueryVisitor
+from hiku.types import (
+    InterfaceRefMeta,
+    OptionalMeta,
+    Record,
+    RecordMeta,
+    RefMeta,
+    SequenceMeta,
+    TypeRefMeta,
+    UnionRefMeta,
+    get_type,
+)
+
+
+def get_ref_type(types, type_, name):
+    if isinstance(type_, RecordMeta):
+        type_ = type_.__field_types__[name]
+        if isinstance(type_, TypeRefMeta):
+            return type_
+        elif isinstance(type_, SequenceMeta):
+            type_ref = type_.__item_type__
+            if isinstance(type_ref, OptionalMeta):  # Ref ?
+                type_ref = type_ref.__type__
+            assert isinstance(type_ref, RefMeta), type_ref
+            return type_ref
+        elif isinstance(type_, InterfaceRefMeta):
+            return type_
+        elif isinstance(type_, OptionalMeta):
+            return type_.__type__
+        return get_ref_type(types, type_.__field_types__[name], name)
+    elif isinstance(type_, UnionRefMeta):
+        # TODO: finish
+        return type_
+    elif isinstance(type_, InterfaceRefMeta):
+        # TODO: finish
+        return type_
+    elif isinstance(type_, TypeRefMeta):
+        type_ = get_type(types, type_)
+        return get_ref_type(types, type_, name)
+    else:
+        raise AssertionError(repr(type_))
+
+
+class QueryMerger(QueryVisitor):
+    def __init__(self, graph: Graph):
+        self.graph = graph
+        self._types = graph.__types__
+        self._type: t.Deque[
+            t.Union[t.Type[Record], Union, Interface, BaseEnum]
+        ] = deque([self._types["__root__"]])
+
+        self._visited_fields = deque([set()])
+
+    def merge(self, query: Node) -> Node:
+        return self.visit(query)
+
+    @property
+    def parent_type(
+        self,
+    ) -> t.Union[t.Type[Record], Union, Interface, BaseEnum]:
+        return self._type[-1]
+
+    @contextmanager
+    def with_type_info(self, obj: Link):
+        ref_type = get_ref_type(self._types, self._type[-1], obj.name)
+
+        self._type.append(ref_type)
+        yield
+        self._type.pop()
+
+    def visit_node(self, node: Node) -> None:
+        return self._merge_nodes([node])
+
+    def _collect_fields(self, node: Node, fields, links, fragments) -> None:
+        for field in node.fields:
+            name = field.alias or field.name
+
+            if isinstance(field, Field):
+                if name not in self._visited_fields[-1]:
+                    fields[name] = field
+            elif isinstance(field, Link):
+                links.setdefault(name, []).append(field)
+
+        fragments_by_type_name = {}
+
+        # TODO: determine fragments parsing rules
+        for fr in node.fragments:
+            if is_fragment_condition_match(self.graph, self.parent_type, fr):
+                self._collect_fields(fr.node, fields, links, fragments)
+            else:
+                fragments_by_type_name.setdefault(fr.type_name, []).append(fr)
+
+        for frs in fragments_by_type_name.values():
+            fragments.append(self._merge_fragments(frs))
+
+    def visit_link(self, obj: Link) -> t.Any:
+        with self.with_type_info(obj):
+            return super().visit_link(obj)
+
+    def _merge_fragments(self, fragments: t.List[Fragment]) -> Fragment:
+        fr = fragments[0]
+        new = Fragment(
+            fr.name,
+            fr.type_name,
+            self._merge_nodes([fr.node for fr in fragments]).fields,
+        )
+        return new
+
+    def _merge_nodes(self, nodes: t.List[Node]) -> Node:
+        """Collect fields from multiple nodes and return new node with them.
+        The main difference from `merge` is that it collects fields
+        from fragments and drops fragments.
+        """
+        assert isinstance(nodes, Sequence), type(nodes)
+        ordered = any(n.ordered for n in nodes)
+
+        fields_map = {}
+        links_map = {}
+        fragments = []
+
+        for node in nodes:
+            self._collect_fields(node, fields_map, links_map, fragments)
+
+        fields = []
+        for field in fields_map.values():
+            fields.append(field)
+
+        for links in links_map.values():
+            fields.append(self._merge_links(links))
+
+        return Node(fields=fields, fragments=fragments, ordered=ordered)
+
+    def _merge_links(self, links: t.List[Link]) -> Link:
+        """Recursively merge link node fields and return new link"""
+        link = links[0]
+
+        directives = []
+        for link in links:
+            directives.extend(link.directives)
+
+        with self.with_type_info(link):
+            return link.copy(
+                node=self._merge_nodes([link.node for link in links]),
+                directives=tuple(directives),
+            )
+
+
+def is_abstract_link(graphql_link: GraphLink) -> bool:
+    return graphql_link.type_info.type_enum in (
+        LinkType.UNION,
+        LinkType.INTERFACE,
+    )
+
+
+def is_fragment_condition_match(
+    graph: Graph,
+    runtime_type,
+    fragment: Fragment,
+) -> bool:
+    """Check if a fragment is applicable to the given type."""
+    type_name = fragment.type_name
+    if not type_name:
+        return True
+
+    if isinstance(runtime_type, TypeRefMeta):
+        if type_name == runtime_type.__type_name__:
+            return True
+
+    if isinstance(runtime_type, UnionRefMeta):
+        # We do not merge abstract type fragmetns, but we must merge same cocrete type fragments
+        return False
+        union = graph.unions_map[runtime_type.__type_name__]
+        return type_name in union.types
+    if isinstance(runtime_type, InterfaceRefMeta):
+        return False
+        interface_types = graph.interfaces_types[runtime_type.__type_name__]
+        return type_name in interface_types
+
+    return False

--- a/hiku/merge.py
+++ b/hiku/merge.py
@@ -72,6 +72,12 @@ class QueryMerger(QueryVisitor):
         )
 
     def merge(self, query: Node) -> Node:
+        """Merge query node and return new node with merged fields, links
+        and fragments.
+
+        Must be called after the query is validated since we assume that
+        no two fields with the same name+alias are present in same node.
+        """
         return self.visit(query)
 
     @property
@@ -102,6 +108,12 @@ class QueryMerger(QueryVisitor):
         links: t.Dict[str, t.List[Link]],
         fragments: t.List[Fragment],
     ) -> None:
+        """Collect fields, links and fragments from the node.
+
+        Fields collected in the fields dict. It is safe to assume that after
+        validation, there is no possibility of having two fields with the same
+        name+alias in the same node, hence we can use alias(or name) as a key.
+        """
         for field in node.fields:
             name = field.alias or field.name
 

--- a/hiku/merge.py
+++ b/hiku/merge.py
@@ -1,63 +1,75 @@
-from collections import deque
-from contextlib import contextmanager
 import typing as t
 
+from collections import defaultdict, deque
+from contextlib import contextmanager
 from collections.abc import Sequence
 
-from hiku.enum import BaseEnum
-from hiku.graph import Graph, Interface, Link as GraphLink, LinkType, Union
-from hiku.query import Link, Field, Fragment, Node, QueryVisitor
+from hiku.directives import Directive
+from hiku.graph import Graph, Interface
+from hiku.query import FieldOrLink, Link, Field, Fragment, Node, QueryVisitor
 from hiku.types import (
     InterfaceRefMeta,
     OptionalMeta,
     Record,
     RecordMeta,
     RefMeta,
+    RefMetaTypes,
     SequenceMeta,
     TypeRefMeta,
+    Types,
     UnionRefMeta,
     get_type,
 )
 
 
-def get_ref_type(types, type_, name):
+def get_ref_type(
+    types: Types, type_: t.Union[t.Type[Record], RefMetaTypes], name: str
+) -> RefMetaTypes:
     if isinstance(type_, RecordMeta):
         type_ = type_.__field_types__[name]
         if isinstance(type_, TypeRefMeta):
             return type_
-        elif isinstance(type_, SequenceMeta):
-            type_ref = type_.__item_type__
-            if isinstance(type_ref, OptionalMeta):  # Ref ?
-                type_ref = type_ref.__type__
-            assert isinstance(type_ref, RefMeta), type_ref
-            return type_ref
-        elif isinstance(type_, InterfaceRefMeta):
-            return type_
-        elif isinstance(type_, OptionalMeta):
-            return type_.__type__
-        return get_ref_type(types, type_.__field_types__[name], name)
+
+        return get_ref_type(types, type_, name)
+    elif isinstance(type_, OptionalMeta):
+        assert isinstance(type_.__type__, RefMeta), type_.__type__
+        return type_.__type__
     elif isinstance(type_, UnionRefMeta):
-        # TODO: finish
         return type_
     elif isinstance(type_, InterfaceRefMeta):
-        # TODO: finish
         return type_
     elif isinstance(type_, TypeRefMeta):
         type_ = get_type(types, type_)
         return get_ref_type(types, type_, name)
+    elif isinstance(type_, SequenceMeta):
+        type_ref = type_.__item_type__
+        if isinstance(type_ref, OptionalMeta):
+            type_ref = type_ref.__type__
+        assert isinstance(type_ref, RefMeta), type_ref
+        return type_ref
     else:
         raise AssertionError(repr(type_))
+
+
+def is_match_type(
+    type_: t.Union[t.Type[Record], RefMetaTypes], fragment: Fragment
+) -> bool:
+    if fragment.type_name is None:
+        return True
+
+    if isinstance(type_, RecordMeta):
+        return False
+
+    return fragment.type_name == type_.__type_name__
 
 
 class QueryMerger(QueryVisitor):
     def __init__(self, graph: Graph):
         self.graph = graph
         self._types = graph.__types__
-        self._type: t.Deque[
-            t.Union[t.Type[Record], Union, Interface, BaseEnum]
-        ] = deque([self._types["__root__"]])
-
-        self._visited_fields = deque([set()])
+        self._type: t.Deque[t.Union[t.Type[Record], RefMetaTypes]] = deque(
+            [self._types["__root__"]]
+        )
 
     def merge(self, query: Node) -> Node:
         return self.visit(query)
@@ -65,71 +77,176 @@ class QueryMerger(QueryVisitor):
     @property
     def parent_type(
         self,
-    ) -> t.Union[t.Type[Record], Union, Interface, BaseEnum]:
+    ) -> t.Union[t.Type[Record], RefMetaTypes]:
         return self._type[-1]
 
     @contextmanager
-    def with_type_info(self, obj: Link):
+    def _with_type_info(self, obj: Link) -> t.Iterator[None]:
         ref_type = get_ref_type(self._types, self._type[-1], obj.name)
 
         self._type.append(ref_type)
         yield
         self._type.pop()
 
-    def visit_node(self, node: Node) -> None:
+    def visit_node(self, node: Node) -> Node:
         return self._merge_nodes([node])
 
-    def _collect_fields(self, node: Node, fields, links, fragments) -> None:
+    def visit_link(self, obj: Link) -> t.Any:
+        with self._with_type_info(obj):
+            return super().visit_link(obj)
+
+    def _collect_fields(
+        self,
+        node: Node,
+        fields: t.Dict[str, Field],
+        links: t.Dict[str, t.List[Link]],
+        fragments: t.List[Fragment],
+    ) -> None:
         for field in node.fields:
             name = field.alias or field.name
 
             if isinstance(field, Field):
-                if name not in self._visited_fields[-1]:
+                if name not in fields:
                     fields[name] = field
             elif isinstance(field, Link):
                 links.setdefault(name, []).append(field)
 
-        fragments_by_type_name = {}
-
-        # TODO: determine fragments parsing rules
+        fragments_to_process: t.List[Fragment] = []
         for fr in node.fragments:
-            if is_fragment_condition_match(self.graph, self.parent_type, fr):
-                self._collect_fields(fr.node, fields, links, fragments)
+            if is_match_type(self.parent_type, fr):
+                self._expand_fragment(fr, fields, links, fragments_to_process)
             else:
-                fragments_by_type_name.setdefault(fr.type_name, []).append(fr)
+                fragments_to_process.append(fr)
 
-        for frs in fragments_by_type_name.values():
-            fragments.append(self._merge_fragments(frs))
-
-    def visit_link(self, obj: Link) -> t.Any:
-        with self.with_type_info(obj):
-            return super().visit_link(obj)
-
-    def _merge_fragments(self, fragments: t.List[Fragment]) -> Fragment:
-        fr = fragments[0]
-        new = Fragment(
-            fr.name,
-            fr.type_name,
-            self._merge_nodes([fr.node for fr in fragments]).fields,
+        self._merge_fragments(
+            fragments_to_process,
+            fields,
+            links,
+            fragments,
         )
-        return new
+
+    def _collect_interface_fields(
+        self,
+        fragment: Fragment,
+        interface: Interface,
+        fields: t.Dict[str, Field],
+        links: t.Dict[str, t.List[Link]],
+    ) -> t.Optional[Fragment]:
+        """For interface fragment, we collect/extract fields that are
+        declared in the interface. The rest of the fields are left in
+        the fragment.
+        """
+        fragment_fields: t.List[FieldOrLink] = []
+
+        for field in fragment.node.fields:
+            name = field.alias or field.name
+            is_interface_field = name in interface.fields_map
+            if isinstance(field, Field):
+                if is_interface_field:
+                    if name not in fields:
+                        fields[name] = field
+                else:
+                    fragment_fields.append(field)
+            elif isinstance(field, Link):
+                if is_interface_field:
+                    links.setdefault(name, []).append(field)
+                else:
+                    fragment_fields.append(field)
+
+        if fragment_fields:
+            return fragment.copy(node=Node(fragment_fields))
+
+        return None
+
+    def _merge_fragments(
+        self,
+        fragments_to_process: t.List[Fragment],
+        fields: t.Dict[str, Field],
+        links: t.Dict[str, t.List[Link]],
+        fragments: t.List[Fragment],
+    ) -> None:
+        """Merge fragments. Depending on the type of the parent type,
+        the fragments are merged differently.
+
+        For example for interfaces/unions we apply diffrent logic when
+        collecting fields and links.
+        """
+        fragments_by_type: t.DefaultDict[str, t.List[Fragment]] = defaultdict(
+            list
+        )
+
+        for fragment in fragments_to_process:
+            if fragment.type_name is None or (
+                isinstance(self.parent_type, TypeRefMeta)
+                and fragment.type_name == self.parent_type.__type_name__
+            ):
+                self._collect_fields(fragment.node, fields, links, fragments)
+            elif isinstance(self.parent_type, InterfaceRefMeta):
+                assert fragment.type_name is not None
+                new_fragment = self._collect_interface_fields(
+                    fragment,
+                    self.graph.interfaces_map[self.parent_type.__type_name__],
+                    fields,
+                    links,
+                )
+                if new_fragment is not None:
+                    fragments_by_type[fragment.type_name].append(new_fragment)
+            else:
+                # for the rest of the cases(including unions), we just collect
+                # fragments and then merge them by type reducing duplicates
+                fragments_by_type[fragment.type_name].append(fragment)
+
+        for frs in fragments_by_type.values():
+            fragments.append(self._merge_same_type_fragments(frs))
+
+    def _merge_same_type_fragments(
+        self, fragments: t.List[Fragment]
+    ) -> Fragment:
+        return fragments[0].copy(
+            node=self._merge_nodes([fr.node for fr in fragments]),
+        )
+
+    def _expand_fragment(
+        self,
+        fragment: Fragment,
+        fields: t.Dict[str, Field],
+        links: t.Dict[str, t.List[Link]],
+        fragments: t.List[Fragment],
+    ) -> None:
+        """Given a fragment, expand it and collect fields, links and fragments.
+        Fragment is disposed.
+        Example, expand QueryFragment:
+        Given:
+            query { ...QueryFragment }
+            fragment QueryFragment on Query { id ... on Query { name } }
+        Result:
+            query { id name }
+        """
+        for field in fragment.node.fields:
+            name = field.alias or field.name
+
+            if isinstance(field, Field):
+                if name not in fields:
+                    fields[name] = field
+            elif isinstance(field, Link):
+                links.setdefault(name, []).append(field)
+
+        for fr in fragment.node.fragments:
+            fragments.append(fr)
 
     def _merge_nodes(self, nodes: t.List[Node]) -> Node:
-        """Collect fields from multiple nodes and return new node with them.
-        The main difference from `merge` is that it collects fields
-        from fragments and drops fragments.
-        """
+        """Collect fields from multiple nodes and return new node with them"""
         assert isinstance(nodes, Sequence), type(nodes)
         ordered = any(n.ordered for n in nodes)
 
-        fields_map = {}
-        links_map = {}
-        fragments = []
+        fields_map: t.Dict[str, Field] = {}
+        links_map: t.Dict[str, t.List[Link]] = {}
+        fragments: t.List[Fragment] = []
 
         for node in nodes:
             self._collect_fields(node, fields_map, links_map, fragments)
 
-        fields = []
+        fields: t.List[FieldOrLink] = []
         for field in fields_map.values():
             fields.append(field)
 
@@ -142,46 +259,12 @@ class QueryMerger(QueryVisitor):
         """Recursively merge link node fields and return new link"""
         link = links[0]
 
-        directives = []
+        directives: t.List[Directive] = []
         for link in links:
             directives.extend(link.directives)
 
-        with self.with_type_info(link):
+        with self._with_type_info(link):
             return link.copy(
                 node=self._merge_nodes([link.node for link in links]),
                 directives=tuple(directives),
             )
-
-
-def is_abstract_link(graphql_link: GraphLink) -> bool:
-    return graphql_link.type_info.type_enum in (
-        LinkType.UNION,
-        LinkType.INTERFACE,
-    )
-
-
-def is_fragment_condition_match(
-    graph: Graph,
-    runtime_type,
-    fragment: Fragment,
-) -> bool:
-    """Check if a fragment is applicable to the given type."""
-    type_name = fragment.type_name
-    if not type_name:
-        return True
-
-    if isinstance(runtime_type, TypeRefMeta):
-        if type_name == runtime_type.__type_name__:
-            return True
-
-    if isinstance(runtime_type, UnionRefMeta):
-        # We do not merge abstract type fragmetns, but we must merge same cocrete type fragments
-        return False
-        union = graph.unions_map[runtime_type.__type_name__]
-        return type_name in union.types
-    if isinstance(runtime_type, InterfaceRefMeta):
-        return False
-        interface_types = graph.interfaces_types[runtime_type.__type_name__]
-        return type_name in interface_types
-
-    return False

--- a/hiku/query.py
+++ b/hiku/query.py
@@ -58,7 +58,6 @@ from typing_extensions import TypeAlias
 
 from .directives import Directive
 from .utils import cached_property
-from hiku import directives
 
 T = t.TypeVar("T", bound="Base")
 
@@ -274,11 +273,11 @@ class Fragment(Base):
         self,
         name: t.Optional[str],
         type_name: t.Optional[str],
-        fields: t.List[FieldOrLink],
+        node: Node,
     ) -> None:
         self.name = name  # if None, it's an inline fragment
         self.type_name = type_name
-        self.node = Node(fields)
+        self.node = node
 
     def accept(self, visitor: "QueryVisitor") -> t.Any:
         return visitor.visit_fragment(self)

--- a/hiku/readers/graphql.py
+++ b/hiku/readers/graphql.py
@@ -319,7 +319,9 @@ class SelectionSetVisitMixin:
             return
 
         yield Fragment(
-            None, obj.type_condition.name.value, self._collect_fields(obj)
+            None,
+            obj.type_condition.name.value if obj.type_condition else None,
+            self._collect_fields(obj),
         )
 
 

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -91,10 +91,9 @@ class Proxy:
         try:
             field: t.Union[Field, Link] = self.__node__.result_map[item]
         except KeyError:
-            if self.__ref__.node not in self.__node__.fragments_map:
-                raise KeyError(
-                    "Field {!r} wasn't requested in the query".format(item)
-                )
+            raise KeyError(
+                "Field {!r} wasn't requested in the query".format(item)
+            )
 
         try:
             obj: t.Dict = self.__idx__[self.__ref__.node][self.__ref__.ident]
@@ -104,6 +103,7 @@ class Proxy:
                     self.__ref__.node, self.__ref__.ident
                 )
             )
+
         try:
             value: t.Any = obj[field.index_key]
         except KeyError:

--- a/hiku/result.py
+++ b/hiku/result.py
@@ -96,15 +96,6 @@ class Proxy:
                     "Field {!r} wasn't requested in the query".format(item)
                 )
 
-            try:
-                field = self.__node__.fragments_map[
-                    self.__ref__.node
-                ].node.result_map[item]
-            except KeyError:
-                raise KeyError(
-                    "Field {!r} wasn't requested in the query".format(item)
-                )
-
         try:
             obj: t.Dict = self.__idx__[self.__ref__.node][self.__ref__.ident]
         except KeyError:

--- a/hiku/sources/graph.py
+++ b/hiku/sources/graph.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import (
     NoReturn,
     List,
+    Tuple,
     Union,
     Callable,
     Iterator,
@@ -21,11 +22,15 @@ from ..graph import (
     Field,
 )
 from ..types import TypeRef, Sequence
-from ..query import merge, Node as QueryNode, Field as QueryField
+from ..query import (
+    merge,
+    Node as QueryNode,
+    Field as QueryField,
+    Link as QueryLink,
+)
 from ..types import Any
 from ..engine import (
     Query,
-    FieldGroup,
     Context,
 )
 from ..expr.refs import RequirementsExtractor
@@ -40,6 +45,7 @@ from ..expr.checker import check, fn_types
 from ..expr.compiler import ExpressionCompiler
 
 
+FieldGroup = Tuple[Field, Union[QueryField, QueryLink]]
 Expr: TypeAlias = Union[_Func, DotHandler]
 
 
@@ -176,7 +182,12 @@ class SubGraph:
 
         q = Query(queue, task_set, self.graph, reqs, ctx)
         q.process_link(
-            path, self.graph.root, this_graph_link, this_query_link, None, ids
+            path,
+            self.graph.root,
+            this_graph_link,
+            this_query_link,
+            None,
+            ids,
         )
         q.process_node(path, self.graph.root, other_reqs, None)
         return _create_result_proc(q, procs, option_values)

--- a/hiku/types.py
+++ b/hiku/types.py
@@ -294,6 +294,7 @@ class EnumRef(metaclass=EnumRefMeta):
 
 
 RefMeta = (TypeRefMeta, UnionRefMeta, InterfaceRefMeta, EnumRefMeta)
+RefMetaTypes = t.Union[TypeRefMeta, UnionRefMeta, InterfaceRefMeta, EnumRefMeta]
 
 
 @t.overload

--- a/tests/benchmarks/test_read_graphql.py
+++ b/tests/benchmarks/test_read_graphql.py
@@ -51,7 +51,7 @@ def test_link_fragment(benchmark):
                 Field("id"),
             ],
             [
-                Fragment("User", [
+                Fragment(None, "User", [
                     Field("name"),
                 ])
             ]

--- a/tests/benchmarks/test_read_graphql.py
+++ b/tests/benchmarks/test_read_graphql.py
@@ -42,7 +42,7 @@ def test_link_fragment(benchmark):
             }
         }
     }
-    
+
     """
     parsed_query = benchmark(read, query, None)
     assert parsed_query == Node([
@@ -51,9 +51,9 @@ def test_link_fragment(benchmark):
                 Field("id"),
             ],
             [
-                Fragment(None, "User", [
+                Fragment(None, "User", Node([
                     Field("name"),
-                ])
+                ]))
             ]
         ))
     ])

--- a/tests/test_federation/test_engine.py
+++ b/tests/test_federation/test_engine.py
@@ -1,7 +1,6 @@
 import pytest
 from hiku.graph import Graph
 
-from hiku.context import create_execution_context
 from hiku.query import Node, Field, Link
 from hiku.executors.asyncio import AsyncIOExecutor
 from hiku.federation.endpoint import denormalize_entities
@@ -43,7 +42,6 @@ ENTITIES_QUERY = {
         ]
     }
 }
-QUERY = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
 
 
 SDL_QUERY = Node(fields=[
@@ -52,15 +50,17 @@ SDL_QUERY = Node(fields=[
 
 
 def test_validate_entities_query():
-    errors = validate(GRAPH, QUERY)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    errors = validate(GRAPH, query)
     assert errors == []
 
 
 def test_execute_sync_executor():
-    result = execute(QUERY, GRAPH)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    result = execute(query, GRAPH)
     data = denormalize_entities(
         GRAPH,
-        QUERY,
+        query,
         result,
     )
 
@@ -73,10 +73,11 @@ def test_execute_sync_executor():
 
 @pytest.mark.asyncio
 async def test_execute_async_executor():
-    result = await execute_async(QUERY, ASYNC_GRAPH)
+    query = read(ENTITIES_QUERY['query'], ENTITIES_QUERY['variables'])
+    result = await execute_async(query, ASYNC_GRAPH)
     data = denormalize_entities(
         GRAPH,
-        QUERY,
+        query,
         result,
     )
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -430,6 +430,40 @@ def test_validate_query_implementation_node_field_without_inline_fragment():
         "Did you mean to use an inline fragment on 'Audio'?"
     ]
 
+def test_validate_query_fragment_no_type_condition():
+    query = """
+    query GetMedia {
+      media {
+        ... {
+          album
+        }
+      }
+    }
+    """
+
+    errors = validate(GRAPH, read(query, {'text': 'foo'}))
+
+    assert errors == [
+      "Can not query field 'album' on type 'Media'. "
+      "Did you mean to use an inline fragment on 'Audio'?"
+    ]
+
+
+def test_validate_query_fragment_on_unknown_type():
+    query = """
+    query GetMedia {
+      media {
+        ... on X {
+          duration
+        }
+      }
+    }
+    """
+
+    errors = validate(GRAPH, read(query, {'text': 'foo'}))
+
+    assert errors == ["Fragment on unknown type 'X'"]
+
 
 def test_validate_interface_type_has_no_such_field():
     query = """

--- a/tests/test_query_merger.py
+++ b/tests/test_query_merger.py
@@ -1,0 +1,319 @@
+import pytest
+
+from graphql import print_ast
+from graphql.language.parser import parse
+from hiku.export.graphql import export
+
+from hiku.graph import Field, Graph, Interface, Link, Node, Option, Root, Union
+from hiku.merge import QueryMerger
+from hiku.types import Boolean, Integer, InterfaceRef, Optional, String, TypeRef, UnionRef, Sequence
+from hiku.readers.graphql import read
+
+
+def mock_resolve():
+    ...
+
+
+GRAPH = Graph(
+        [
+            Node(
+                "User",
+                [
+                    Field("id", String, mock_resolve),
+                    Field("name", String, mock_resolve, options=[
+                        Option("capitalize", Optional[Boolean], default=False)
+                    ]),
+                    Link("info", TypeRef["Info"], mock_resolve, requires=None),
+                    Link('playlist', Sequence[InterfaceRef['Media']], mock_resolve, requires=None)
+                ],
+            ),
+            Node(
+                "Info",
+                [
+                    Field("email", String, mock_resolve),
+                    Field("phone", String, mock_resolve),
+                    Link("transport", Optional[UnionRef["Transport"]], mock_resolve, requires=None)
+                ],
+            ),
+            Node(
+                "Context",
+                [
+                    Link("user", TypeRef["User"], mock_resolve, requires=None)
+                ],
+            ),
+            Node(
+                "Audio",
+                [
+                    Field("format", String, mock_resolve),
+                ],
+                implements=["Media"],
+            ),
+            Node(
+                "Video",
+                [
+                    Field("codec", String, mock_resolve),
+                ],
+                implements=["Media"],
+            ),
+            Node(
+                "Car",
+                [
+                    Field("model", String, mock_resolve),
+                    Field("year", String, mock_resolve),
+                ],
+            ),
+            Node(
+                "Bike",
+                [
+                    Field("model", String, mock_resolve),
+                ],
+            ),
+            Root(
+                [Link("context", TypeRef["Context"], mock_resolve, requires=None)]
+            ),
+        ],
+        interfaces=[
+            Interface(
+                "Media",
+                [Field("duration", Integer, mock_resolve)],
+            )
+        ],
+        unions=[Union("Transport", ["Car", "Bike"])],
+    )
+
+
+@pytest.mark.parametrize("src,result", [
+    pytest.param(
+        """
+        query TestQuery {
+            context {
+                user {
+                    id
+                    name
+                    capName: name(capitalize: true)
+                    info {
+                        email
+                        phone
+                        transport {
+                            ... on Car { model year }
+                            ... on Bike { model }
+                        }
+                    }
+                    playlist {
+                        ... on Audio { duration format }
+                        ... on Video { duration codec }
+                    }
+                }
+            }
+        }
+        """,
+        """
+        {
+            context {
+                user {
+                    id
+                    name
+                    capName: name(capitalize: true)
+                    info {
+                        email
+                        phone
+                        transport {
+                            ... on Car { model year }
+                            ... on Bike { model }
+                        }
+                    }
+                    playlist {
+                        duration
+                        ... on Audio { format }
+                        ... on Video { codec }
+                    }
+                }
+            }
+        }
+        """,
+        id="full query",
+    ),
+    pytest.param(
+        """
+        query TestQuery {
+            context { ...ContextFragment }
+        }
+        fragment ContextFragment on Context {
+            ...ContextFragmentA
+            ...ContextFragmentB
+        }
+        fragment ContextFragmentA on Context {
+            user { id name }
+        }
+        fragment ContextFragmentB on Context {
+            user { id }
+        }
+        """,
+        """
+        { context { user { id name } } }
+        """,
+        id="only nested fragments",
+    ),
+    pytest.param(
+        """
+        query TestQuery {
+            context { user { id info { email } } ...ContextFragment }
+        }
+        fragment ContextFragment on Context {
+            ...ContextFragmentA
+            ...ContextFragmentB
+        }
+        fragment ContextFragmentA on Context {
+            user { id name }
+        }
+        fragment ContextFragmentB on Context {
+            user { id info { phone } }
+        }
+        """,
+        """
+        { context { user { id name info { email phone } } } }
+        """,
+        id="fields + fragments",
+    ),
+    pytest.param(
+        """
+        query TestQuery {
+            context { user { id } ...ContextFragment }
+        }
+        fragment ContextFragment on Context {
+            ...ContextFragmentA
+            ...ContextFragmentB
+        }
+        fragment ContextFragmentA on Context {
+            user { id name }
+        }
+        fragment ContextFragmentB on Context {
+            user { id capName: name(capitalize: true) }
+        }
+        """,
+        """
+        { context { user { id name capName: name(capitalize: true) } } }
+        """,
+        id="fields + aliases + fragments",
+    ),
+])
+def test_query_merger(src, result):
+    exp = print_ast(parse(result)).strip()
+
+    query = QueryMerger(GRAPH).merge(read(src))
+    got = print_ast(export(query)).strip()
+
+    assert got == exp
+
+
+
+@pytest.mark.parametrize("src,result", [
+    pytest.param(
+        """
+        query TestQuery {
+            context { user { info { transport {
+                ... on Car { year }
+                ...TransportFragment
+            } } } }
+        }
+        fragment TransportFragment on Transport {
+            ... on Car { year }
+            ... on Car { model }
+            ... on Bike { model }
+        }
+        """,
+        """
+        { context { user { info { transport {
+            ... on Car { year model }
+            ... on Bike { model }
+        } } } } }
+        """,
+        id="union fragments inside fragment",
+    ),
+    pytest.param(
+        """
+        query TestQuery { context { user { info { transport {
+            ... on Car { year }
+            ... on Car { model }
+            ... on Bike { model }
+        } } } } }
+        """,
+        """
+        { context { user { info { transport {
+            ... on Car { year model }
+            ... on Bike { model }
+        } } } } }
+        """,
+        id="union fragments flat",
+    ),
+])
+def test_query_merger__unions(src, result):
+    exp = print_ast(parse(result)).strip()
+    query = read(src)
+    query = QueryMerger(GRAPH).merge(query)
+    got = print_ast(export(query)).strip()
+
+    assert got == exp
+
+
+@pytest.mark.parametrize("src,result", [
+    pytest.param(
+        """
+        query TestQuery { context { user { playlist {
+            ... on Audio { duration format }
+            ... on Video { duration codec }
+        } } } }
+        """,
+        """
+        { context { user { playlist {
+            duration
+            ... on Audio { format }
+            ... on Video { codec }
+        } } } }
+        """,
+        id="interface fragments - fields inside fragments",
+    ),
+    pytest.param(
+        """
+        query TestQuery { context { user { playlist {
+            duration
+            ... on Audio { format }
+            ... on Video { duration codec }
+        } } } }
+        """,
+        """
+        { context { user { playlist {
+            duration
+            ... on Audio { format }
+            ... on Video { codec }
+        } } } }
+        """,
+        id="interface fragments - fields inside and outside fragments",
+    ),
+    pytest.param(
+        """
+        query TestQuery { context { user { playlist {
+            ...PlaylistFragment
+        } } } }
+        fragment PlaylistFragment on Media {
+            ... on Audio { duration format }
+            ... on Video { duration codec }
+        }
+        """,
+        """
+        { context { user { playlist {
+            duration
+            ... on Audio { format }
+            ... on Video { codec }
+        } } } }
+        """,
+        id="interface fragments - fragments inside fragments",
+    ),
+])
+def test_query_merger__interfaces(src, result):
+    exp = print_ast(parse(result)).strip()
+
+    query = QueryMerger(GRAPH).merge(read(src))
+    got = print_ast(export(query)).strip()
+
+    assert got == exp

--- a/tests/test_read_graphql.py
+++ b/tests/test_read_graphql.py
@@ -190,7 +190,14 @@ def test_named_fragments() -> None:
                     Node([Field("rusk")]),
                 ),
             ],
-            [],
+            [
+                Fragment("Meer", 'Torsion', [
+                    Link(
+                        "kilned",
+                        Node([Field("rusk")]),
+                    ),
+                ]),
+            ],
         ),
     )
 
@@ -202,7 +209,7 @@ def test_named_fragments() -> None:
                 Field("apres"),
             ],
             [
-                Fragment('Makai', [
+                Fragment("Goaded", 'Makai', [
                     Field("doozie"),
                     PinsLink
                 ]),
@@ -218,7 +225,7 @@ def test_named_fragments() -> None:
                 SneezerLink
             ],
             [
-                Fragment("Valium", [
+                Fragment(None, "Valium", [
                     Link(
                         "movies",
                         Node([Field("boree")]),
@@ -599,12 +606,14 @@ def test_parse_union_with_two_fragments():
                     Node([
                         Field("__typename"),
                         ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("id"),
                             Field("duration"),
                         ]),
-                        Fragment('Video', [
+                        Fragment('VideoId', 'Video', [
                             Field("id"),
+                        ]),
+                        Fragment(None, 'Video', [
                             Field("thumbnailUrl"),
                         ]),
                     ]),
@@ -634,7 +643,7 @@ def test_parse_union_with_one_fragment():
                     Node([
                         Field("__typename"),
                     ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("id"),
                             Field("duration"),
                         ]),
@@ -672,10 +681,10 @@ def test_parse_interface_with_two_fragments():
                         Field("id"),
                         Field("duration"),
                         ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("album"),
                         ]),
-                        Fragment('Video', [
+                        Fragment(None, 'Video', [
                             Field("thumbnailUrl"),
                         ]),
                     ])
@@ -708,7 +717,7 @@ def test_parse_interface_with_one_fragment():
                         Field("id"),
                         Field("duration"),
                     ], [
-                        Fragment('Audio', [
+                        Fragment(None, 'Audio', [
                             Field("album"),
                         ]),
                     ]),
@@ -752,11 +761,21 @@ def test_merge_node_with_fragment_on_node() -> None:
                             Field("id"),
                             Field("name"),
                         ], [
-                            Fragment('User', [
+                            Fragment(None, 'User', [
+                                Field("id"),
                                 Field("email"),
                             ]),
                         ])),
-                    ], []),
+                    ], [
+                        Fragment(None, 'Context', [
+                            Link("user", Node([], [
+                                Fragment(None, 'User', [
+                                    Field("id"),
+                                    Field("email"),
+                                ]),
+                            ])),
+                        ]),
+                    ]),
                 )
             ]
         ),
@@ -799,11 +818,21 @@ def test_merge_fragment_for_union() -> None:
                             Field("id"),
                             Field("name"),
                         ], [
-                            Fragment('User', [
+                            Fragment(None, 'User', [
+                                Field("id"),
                                 Field("email"),
                             ]),
                         ])),
-                    ], []),
+                    ], [
+                        Fragment(None, 'Context', [
+                            Link("user", Node([], [
+                                Fragment(None, 'User', [
+                                    Field("id"),
+                                    Field("email"),
+                                ]),
+                            ])),
+                        ]),
+                    ]),
                 )
             ]
         ),

--- a/tests/test_read_graphql.py
+++ b/tests/test_read_graphql.py
@@ -191,12 +191,12 @@ def test_named_fragments() -> None:
                 ),
             ],
             [
-                Fragment("Meer", 'Torsion', [
+                Fragment("Meer", 'Torsion', Node([
                     Link(
                         "kilned",
                         Node([Field("rusk")]),
                     ),
-                ]),
+                ])),
             ],
         ),
     )
@@ -209,10 +209,10 @@ def test_named_fragments() -> None:
                 Field("apres"),
             ],
             [
-                Fragment("Goaded", 'Makai', [
+                Fragment("Goaded", 'Makai', Node([
                     Field("doozie"),
                     PinsLink
-                ]),
+                ])),
             ]
         ),
         options={"gire": "noatak"},
@@ -225,12 +225,12 @@ def test_named_fragments() -> None:
                 SneezerLink
             ],
             [
-                Fragment(None, "Valium", [
+                Fragment(None, "Valium", Node([
                     Link(
                         "movies",
                         Node([Field("boree")]),
                     ),
-                ]),
+                ])),
             ]
         ),
     )
@@ -369,11 +369,12 @@ def test_variables_in_fragment():
         }
         """,
         Node(
+            [],
             [
-                Field(
+                Fragment("Pujari", "Ashlee", Node([Field(
                     "fibbery",
                     options={"baps": None, "bankit": 123, "riuer": 234},
-                )
+                )]))
             ]
         ),
         {"popedom": 123},
@@ -454,7 +455,7 @@ def test_skip_fragment_spread(skip):
           bar
         }
         """,
-        Node([Field("foo")] + ([] if skip else [Field("bar")])),
+        Node([Field("foo")], ([] if skip else [Fragment("Fragment", "Thing", Node([Field("bar")]))])),
         {"cond": skip},
     )
 
@@ -470,7 +471,7 @@ def test_skip_inline_fragment(skip):
           }
         }
         """,
-        Node([Field("foo")] + ([] if skip else [Field("bar")])),
+        Node([Field("foo")], ([] if skip else [Fragment(None, "Thing", Node([Field("bar")]))])),
         {"cond": skip},
     )
 
@@ -501,7 +502,7 @@ def test_include_fragment_spread(include):
           bar
         }
         """,
-        Node([Field("foo")] + ([Field("bar")] if include else [])),
+        Node([Field("foo")], ([Fragment("Fragment", "Thing", Node([Field("bar")]))] if include else [])),
         {"cond": include},
     )
 
@@ -517,7 +518,7 @@ def test_include_inline_fragment(include):
           }
         }
         """,
-        Node([Field("foo")] + ([Field("bar")] if include else [])),
+        Node([Field("foo")], ([Fragment(None, "Thing", Node([Field("bar")]))] if include else [])),
         {"cond": include},
     )
 
@@ -576,264 +577,3 @@ def test_read_operation_subscription():
     op = read_operation("subscription { ping }")
     assert op.type is OperationType.SUBSCRIPTION
     assert op.query == Node([Field("ping")])
-
-
-def test_parse_union_with_two_fragments():
-    check_read(
-        """
-        query GetMedia {
-          media {
-            __typename
-            ... on Audio {
-              id
-              duration
-            }
-            ...VideoId
-            ... on Video {
-              thumbnailUrl
-            }
-          }
-        }
-        
-        fragment VideoId on Video {
-          id
-        }
-        """,
-        Node(
-            [
-                Link(
-                    "media",
-                    Node([
-                        Field("__typename"),
-                        ], [
-                        Fragment(None, 'Audio', [
-                            Field("id"),
-                            Field("duration"),
-                        ]),
-                        Fragment('VideoId', 'Video', [
-                            Field("id"),
-                        ]),
-                        Fragment(None, 'Video', [
-                            Field("thumbnailUrl"),
-                        ]),
-                    ]),
-                ),
-            ]
-        ),
-    )
-
-
-def test_parse_union_with_one_fragment():
-    check_read(
-        """
-        query GetMedia {
-          media {
-            __typename
-            ... on Audio {
-              id
-              duration
-            }
-          }
-        }
-        """,
-        Node(
-            [
-                Link(
-                    "media",
-                    Node([
-                        Field("__typename"),
-                    ], [
-                        Fragment(None, 'Audio', [
-                            Field("id"),
-                            Field("duration"),
-                        ]),
-                        ]
-                    )
-                ),
-            ]
-        ),
-    )
-
-
-def test_parse_interface_with_two_fragments():
-    check_read(
-        """
-        query GetMedia {
-          media {
-            __typename
-            id
-            duration
-            ... on Audio {
-              album
-            }
-            ... on Video {
-              thumbnailUrl
-            }
-          }
-        }
-        """,
-        Node(
-            [
-                Link(
-                    "media",
-                    Node([
-                        Field("__typename"),
-                        Field("id"),
-                        Field("duration"),
-                        ], [
-                        Fragment(None, 'Audio', [
-                            Field("album"),
-                        ]),
-                        Fragment(None, 'Video', [
-                            Field("thumbnailUrl"),
-                        ]),
-                    ])
-                )
-            ]
-        ),
-    )
-
-
-def test_parse_interface_with_one_fragment():
-    check_read(
-        """
-        query GetMedia {
-          media {
-            __typename
-            id
-            duration
-            ... on Audio {
-              album
-            }
-          }
-        }
-        """,
-        Node(
-            [
-                Link(
-                    "media",
-                    Node([
-                        Field("__typename"),
-                        Field("id"),
-                        Field("duration"),
-                    ], [
-                        Fragment(None, 'Audio', [
-                            Field("album"),
-                        ]),
-                    ]),
-                )
-            ]
-        ),
-    )
-
-
-def test_merge_node_with_fragment_on_node() -> None:
-    check_read(
-        """
-        query GetContext {
-            context {
-                user {
-                    id
-                    name
-                    ... on User {
-                        id
-                        email
-                    }
-                }
-                ... on Context {
-                    user {
-                        ... on User {
-                            id
-                            email
-                        }
-                    }
-                }
-            }
-        }
-        """,
-
-        Node(
-            [
-                Link(
-                    "context",
-                    Node([
-                        Link("user", Node([
-                            Field("id"),
-                            Field("name"),
-                        ], [
-                            Fragment(None, 'User', [
-                                Field("id"),
-                                Field("email"),
-                            ]),
-                        ])),
-                    ], [
-                        Fragment(None, 'Context', [
-                            Link("user", Node([], [
-                                Fragment(None, 'User', [
-                                    Field("id"),
-                                    Field("email"),
-                                ]),
-                            ])),
-                        ]),
-                    ]),
-                )
-            ]
-        ),
-    )
-
-
-
-def test_merge_fragment_for_union() -> None:
-    """We do not know if fragments are for unions or not when we parsing query"""
-    check_read(
-        """
-        query GetContext {
-            context {
-                user {
-                    id
-                    name
-                    ... on User {
-                        id
-                        email
-                    }
-                }
-                ... on Context {
-                    user {
-                        ... on User {
-                            id
-                            email
-                        }
-                    }
-                }
-            }
-        }
-        """,
-
-        Node(
-            [
-                Link(
-                    "context",
-                    Node([
-                        Link("user", Node([
-                            Field("id"),
-                            Field("name"),
-                        ], [
-                            Fragment(None, 'User', [
-                                Field("id"),
-                                Field("email"),
-                            ]),
-                        ])),
-                    ], [
-                        Fragment(None, 'Context', [
-                            Link("user", Node([], [
-                                Fragment(None, 'User', [
-                                    Field("id"),
-                                    Field("email"),
-                                ]),
-                            ])),
-                        ]),
-                    ]),
-                )
-            ]
-        ),
-    )

--- a/tests_pg/test_source_aiopg.py
+++ b/tests_pg/test_source_aiopg.py
@@ -5,7 +5,7 @@ import aiopg.sa
 import hiku.sources.aiopg
 
 from hiku.engine import Engine
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.asyncio import AsyncIOExecutor
 
 from tests.base import check_result
@@ -36,7 +36,7 @@ class TestSourceAIOPG(SourceSQLAlchemyTestBase):
         engine = Engine(AsyncIOExecutor())
         try:
             result = await engine.execute(
-                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
+                self.graph, read(src), ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:

--- a/tests_pg/test_source_sqlalchemy_asyncpg.py
+++ b/tests_pg/test_source_sqlalchemy_asyncpg.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 import hiku.sources.sqlalchemy_async
 
 from hiku.engine import Engine
-from hiku.readers.simple import read
+from hiku.readers.graphql import read
 from hiku.executors.asyncio import AsyncIOExecutor
 
 from tests.base import check_result
@@ -38,7 +38,7 @@ class TestSourceSQLAlchemyAsyncPG(SourceSQLAlchemyTestBase):
         engine = Engine(AsyncIOExecutor())
         try:
             result = await engine.execute(
-                read(src), self.graph, ctx={SA_ENGINE_KEY: sa_engine}
+                self.graph, read(src), ctx={SA_ENGINE_KEY: sa_engine}
             )
             check_result(result, value)
         finally:


### PR DESCRIPTION
In this PR we addressed the issue with broken fragments merging. Historically, hiku has not supported unions/interfaces so fragments merging were ok. But after we added unions/intefaces support + fragments support, things went in the wrong direction.

Fragments merging (fields merging to be more accurate) has its own rules in graphql spec and we did not complied. So why thought ?

Hiku arhitecture was build without fragments in mind, that is - engine and denormalization modules can not work with fragments. So to avoid complex rewriting for engine and denormalization we decided to merge fragments at query parsing stage to avoid fields duplication - the most hard thing to support in engine.

Doing fragments merging at query parsing stage was a bad decision since
we do not have access to graph, hence can not know how to merge
particular fragment because merge rules for unions and interfaces are
different.

In this PR we introducing new `QueryMerger` that merges fragments after
parsing/validation but before execution, thus we do not need to rewrite the engine much
and make small tweaks to denormalization.

Some other changes:
 - Refactor SplitQuery types, introduce FieldInfo and LinkInfo instead of tuples
 - Refactor GroupQuery to use FieldInfo/LinkInfo
 - Fix cache tests
 - Drop fragments hack from result.py:Proxy since we now provide proper Proxy to index for each fragment
 - Add name for Fragment, if name is None - this is an InlineFragment,
   make type_name optional, because fragments can be without type
   condition
 - Node.fragments_map only returns named fragments map
 - Field/Link `directives` after merge can have multiple same directives. When we construct `directives_map`, we preserve only first occurred directive from list in map.