### PR TITLE
Add sqlalchemy>2 support

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -117,16 +117,20 @@ user_table = Table(
 
 def setup_db(db_engine):
     metadata.create_all(db_engine)
-    for r in [c._asdict() for c in DB["companies"].values()]:
-        db_engine.execute(company_table.insert(), r)
-    for r in [c._asdict() for c in DB["users"].values()]:
-        db_engine.execute(user_table.insert(), r)
-    for r in [p._asdict() for p in DB["attributes"].values()]:
-        db_engine.execute(attribute_table.insert(), r)
-    for r in [p._asdict() for p in DB["attribute_values"].values()]:
-        db_engine.execute(attribute_value_table.insert(), r)
-    for r in [p._asdict() for p in DB["products"].values()]:
-        db_engine.execute(product_table.insert(), r)
+    with db_engine.begin() as db_conn:
+        for r in [c._asdict() for c in DB["companies"].values()]:
+            db_conn.execute(company_table.insert(), r)
+        for r in [c._asdict() for c in DB["users"].values()]:
+            db_conn.execute(user_table.insert(), r)
+        for r in [p._asdict() for p in DB["attributes"].values()]:
+            db_conn.execute(attribute_table.insert(), r)
+        for r in [p._asdict() for p in DB["attribute_values"].values()]:
+            db_conn.execute(attribute_value_table.insert(), r)
+        for r in [p._asdict() for p in DB["products"].values()]:
+            db_conn.execute(product_table.insert(), r)
+
+        if hasattr(db_conn, "commit"):
+            db_conn.commit()
 
 
 class Product(t.NamedTuple):

--- a/tests/test_source_sqlalchemy.py
+++ b/tests/test_source_sqlalchemy.py
@@ -50,23 +50,27 @@ bar_table = Table(
 
 def setup_db(db_engine):
     metadata.create_all(db_engine)
-    for r in [
-        {"id": 0, "name": "bar0", "type": 4},
-        {"id": 4, "name": "bar1", "type": 1},
-        {"id": 5, "name": "bar2", "type": 2},
-        {"id": 6, "name": "bar3", "type": 3},
-    ]:
-        db_engine.execute(bar_table.insert(), r)
-    for r in [
-        {"name": "foo1", "count": 5, "bar_id": None},
-        {"name": "foo2", "count": 10, "bar_id": 5},
-        {"name": "foo3", "count": 15, "bar_id": 4},
-        {"name": "foo4", "count": 20, "bar_id": 6},
-        {"name": "foo5", "count": 25, "bar_id": 5},
-        {"name": "foo6", "count": 30, "bar_id": 4},
-        {"name": "foo7", "count": 35, "bar_id": 0},
-    ]:
-        db_engine.execute(foo_table.insert(), r)
+    with db_engine.begin() as db_conn:
+        for r in [
+            {"id": 0, "name": "bar0", "type": 4},
+            {"id": 4, "name": "bar1", "type": 1},
+            {"id": 5, "name": "bar2", "type": 2},
+            {"id": 6, "name": "bar3", "type": 3},
+        ]:
+            db_conn.execute(bar_table.insert(), r)
+        for r in [
+            {"name": "foo1", "count": 5, "bar_id": None},
+            {"name": "foo2", "count": 10, "bar_id": 5},
+            {"name": "foo3", "count": 15, "bar_id": 4},
+            {"name": "foo4", "count": 20, "bar_id": 6},
+            {"name": "foo5", "count": 25, "bar_id": 5},
+            {"name": "foo6", "count": 30, "bar_id": 4},
+            {"name": "foo7", "count": 35, "bar_id": 0},
+        ]:
+            db_conn.execute(foo_table.insert(), r)
+
+        if hasattr(db_conn, "commit"):
+            db_conn.commit()
 
 
 def graph_factory(

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,28 @@
 [tox]
-envlist = py37,pypy3,py38,py39,py310,py311,p312
+envlist = py37,pypy3,py38,py39,py310,py311,p312,sqla2,sqla13
 
 [testenv]
 groups = dev,test
 commands =
     pytest tests {posargs}
 
+[testenv:sqla2]
+groups = dev,test
+commands =
+    python -I -m pip install 'sqlalchemy>=2.0.0'
+    pytest tests {posargs}
+
+[testenv:sqla13]
+groups = dev,test
+commands =
+    python -I -m pip install 'sqlalchemy>=1.3,<1.4'
+    pytest tests {posargs}
+
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.7: py37,sqla13
+    3.8: py38,sqla13
+    3.9: py39,sqla13
+    3.10: py310,sqla2
+    3.11: py311,sqla2
+    3.12: py312,sqla2


### PR DESCRIPTION
Incompatibilities between sqlalchemy version that were adressed:
- `select([c1, c2])` vs `select(c1, c2)` query syntax
- `row[c]` vs `row._mapping[c]` for accessing result rows attributes 

Modified tox.ini to also run tests with sqlalchemy>=1.3,<1.4 for 3.7,3.8,3.9 and sqlalchemy>=2 for 3.10,3.11,3.12.  
All specified version of python also run tests with sqlalchemy 1.4 as it was before changes