### PR TITLE
Fix handling of numbers without fractional part in Float option

### DIFF
--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -100,6 +100,12 @@ def _yield_options(
         ):
             scalar = graph.scalars_map[option.type_info.type_name]
             yield option.name, serialize(option.type, value, scalar.parse)
+        elif (
+            option.type_info
+            and option.type_info.type_enum is FieldType.SCALAR
+            and option.type
+        ):
+            yield option.name, option.type.parse(value)
         else:
             yield option.name, value
 

--- a/hiku/types.py
+++ b/hiku/types.py
@@ -28,6 +28,14 @@ class GenericMeta(type):
     def accept(cls, visitor: "AbstractTypeVisitor") -> t.Any:
         raise NotImplementedError(type(cls))
 
+    @classmethod
+    def parse(cls, value: str) -> t.Any:
+        return value
+
+    @classmethod
+    def serialize(cls, value: str) -> t.Any:
+        return value
+
 
 class AnyMeta(GenericMeta):
     def accept(cls, visitor: "AbstractTypeVisitor") -> t.Any:
@@ -80,7 +88,9 @@ class FloatMeta(GenericMeta):
 
 
 class Float(metaclass=FloatMeta):
-    pass
+    @classmethod
+    def parse(cls, value: str) -> t.Any:
+        return float(value)
 
 
 TM = t.TypeVar("TM", bound="TypingMeta")

--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -203,7 +203,7 @@ class _OptionTypeValidator:
         return None
 
     def visit_float(self, type_: FloatMeta) -> None:
-        if not isinstance(self.value, float):
+        if not isinstance(self.value, (int, float)):
             raise _OptionTypeError(self.value, type_)
         return None
 

--- a/tests/test_validate_query.py
+++ b/tests/test_validate_query.py
@@ -13,6 +13,7 @@ from hiku.types import (
     Sequence,
     String,
     TypeRef,
+    Float,
 )
 from hiku.validate.query import validate
 
@@ -105,6 +106,13 @@ GRAPH = Graph(
                     _,
                     requires=None,
                     options=[Option("lawing", Optional[Integer], default=None)],
+                ),
+                Link(
+                    "insect",
+                    Sequence[TypeRef["hooted"]],
+                    _,
+                    requires=None,
+                    options=[Option("floating", Optional[Float], default=None)],
                 ),
             ]
         ),
@@ -418,6 +426,15 @@ def test_link_options():
             '"str" instead of Integer',
         ],
     )
+    check_errors(
+        mk("insect", options={"floating": "2"}),
+        [
+            'Invalid value for option "root.insect:floating", '
+            '"str" instead of Float'
+        ],
+    )
+    check_errors(mk("insect", options={"floating": 2.0}), [])
+    check_errors(mk("insect", options={"floating": 2}), [])
 
 
 def test_missing_options():
@@ -469,6 +486,16 @@ def test_scalar_option_type_errors():
         [
             'Invalid value for option "{field}:lawing", '
             '"Invalid" instead of String'
+        ],
+    )
+    check_option_errors([Option("lawing", Float)], {"lawing": 2}, [])
+    check_option_errors([Option("lawing", Float)], {"lawing": 2.0}, [])
+    check_option_errors(
+        [Option("lawing", Float)],
+        {"lawing": Invalid()},
+        [
+            'Invalid value for option "{field}:lawing", '
+            '"Invalid" instead of Float'
         ],
     )
 


### PR DESCRIPTION
**What’s fixed?**

This PR fixes the issue where numbers without a fractional part (integers) were rejected when passed to a GraphQL Float option.

**Why?**

According to the [GraphQL specification](https://spec.graphql.org/October2021/#sec-Float), it’s valid to pass an Int where a Float is expected. Our server validation was too strict, enforcing that the value must be a Python float, even if an int was provided.

**What’s changed?**
	•	Updated the validation logic to allow int values for Float options.
	•	Added type coercion where necessary to ensure integers are accepted and treated as floats internally.