### PR TITLE
Do not add optional option if it is not provided in query arguments

### DIFF
--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -119,11 +119,15 @@ def _yield_options(
                 # to the options dict to notify value absence
                 continue
 
-            input_type = graph.inputs_map[option.type_info.type_name]
-            for arg in input_type.arguments:
-                if arg.name not in value and arg.default is not Nothing:
-                    value[arg.name] = arg.default
-            yield option.name, value
+            if value is None and optional:
+                # if value is None for optional option, return it as None
+                yield option.name, None
+            else:
+                input_type = graph.inputs_map[option.type_info.type_name]
+                for arg in input_type.arguments:
+                    if arg.name not in value and arg.default is not Nothing:
+                        value[arg.name] = arg.default
+                yield option.name, value
         else:
             yield option.name, value
 

--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -217,7 +217,12 @@ class _OptionTypeValidator:
         return None
 
     def visit_optional(self, type_: OptionalMeta) -> None:
-        if self.value is not None:
+        if (
+            # validate optional option not-None value is provided
+            self.value is not None
+            # validate optional option if value is provided in the query
+            and self.value is not Nothing
+        ):
             self.visit(type_.__type__)
         return None
 
@@ -360,7 +365,10 @@ class _ValidateOptions(GraphVisitor):
 
     def visit_option(self, obj: Option) -> None:
         value = self._options.get(obj.name, obj.default)
-        if value is Nothing:
+        optional = isinstance(obj.type, OptionalMeta)
+        if value is Nothing and not optional:
+            # if value is not specified for required argument,
+
             node, field = self.for_
 
             if obj.type and isinstance(obj.type, InputRefMeta):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -688,6 +688,81 @@ def test_link_option_input_ref():
     }
 
 
+def test_link_optional_option_input_ref_not_provided():
+    class CreateUserOpts(TypedDict):
+        input: dict  # CreateUserInput
+
+    @dataclass(frozen=True)
+    class User:
+        id: int
+        first_name: str
+
+    def create_user(
+        options: CreateUserOpts,
+    ) -> User | Nothing:
+        data = options.get("input")
+        if not data:
+            return Nothing
+        return User(1, data["first_name"])
+
+    def map_user(fields, users: list[User]):
+        def get_field(field, user: User):
+            if field.name == "id":
+                return user.id
+            elif field.name == "first_name":
+                return user.first_name
+
+        return [
+            [get_field(field, user) for field in fields]
+            for user in users
+        ]
+
+    graph = Graph(
+        [
+            Node(
+                "User",
+                [
+                    Field("id", Integer, map_user),
+                    Field("first_name", String, map_user),
+                ],
+            ),
+        ],
+        inputs=[
+            Input(
+                "CreateUserInput",
+                [
+                    Option("first_name", String),
+                ]
+            ),
+        ]
+    )
+
+    mutation = Graph.from_graph(graph,
+       Root([
+            Link(
+                "createUser",
+                Optional[TypeRef["User"]],
+                create_user,
+                requires=None,
+                options=[
+                    Option("input", Optional[InputRef["CreateUserInput"]]),
+                ],
+            )
+        ]),
+    )
+
+    query = build([
+        M.createUser[Q.id, Q.first_name]
+    ])
+
+    schema = Schema(SyncExecutor(), graph, mutation=mutation)
+    result = schema.execute_sync(query)
+
+    assert result.data == {
+        "createUser": None
+    }
+
+
 def test_pass_context_field():
     f = pass_context(Mock(return_value=["boiardo"]))
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -688,7 +688,13 @@ def test_link_option_input_ref():
     }
 
 
-def test_link_optional_option_input_ref_not_provided():
+@pytest.mark.parametrize("query_args", [
+    # when input is not provided in the query
+    {},
+    # when input is provided as None
+    {"input": None},
+])
+def test_link_optional_option_input_ref(query_args):
     class CreateUserOpts(TypedDict):
         input: dict  # CreateUserInput
 
@@ -699,7 +705,7 @@ def test_link_optional_option_input_ref_not_provided():
 
     def create_user(
         options: CreateUserOpts,
-    ) -> User | Nothing:
+    ) -> t.Union[User, Nothing]:
         data = options.get("input")
         if not data:
             return Nothing
@@ -752,15 +758,13 @@ def test_link_optional_option_input_ref_not_provided():
     )
 
     query = build([
-        M.createUser[Q.id, Q.first_name]
+        M.createUser(**query_args)[Q.id, Q.first_name]
     ])
 
     schema = Schema(SyncExecutor(), graph, mutation=mutation)
     result = schema.execute_sync(query)
 
-    assert result.data == {
-        "createUser": None
-    }
+    assert result.data == { "createUser": None }
 
 
 def test_pass_context_field():

--- a/tests/test_validate_query.py
+++ b/tests/test_validate_query.py
@@ -452,7 +452,7 @@ def test_missing_options():
     check_option_errors(
         [Option("lawing", Optional[Integer])],
         {},
-        ['Required option "{field}:lawing" is not specified'],
+        [],
     )
     check_option_errors(
         [Option("lawing", Optional[Integer], default=None)],


### PR DESCRIPTION
`Optional[InputRef]` wasn't handled properly when None passed explicitly in the query or argument was not passed at all (absent value).

Now when for `Optiona[InputRef]` we pass None or does not pass argument at all, validation works as expected as well as options processing in `engine.py`.